### PR TITLE
fix: change repository ID to string type for MCP Registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reddit-mcp-buddy",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Clean, LLM-optimized Reddit MCP server. Browse posts, search content, analyze users. No fluff, just Reddit data.",
   "main": "dist/index.js",
   "mcpName": "io.github.karanb192/reddit-mcp-buddy",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.karanb192/reddit-mcp-buddy",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Reddit browser for Claude Desktop and AI assistants. Browse subreddits, search posts, analyze users, and get Reddit insights. Zero setup required - works instantly with optional authentication for 10x more requests.",
   "author": {
     "name": "Karan Bansal",
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/karanb192/reddit-mcp-buddy",
   "bugs": "https://github.com/karanb192/reddit-mcp-buddy/issues",
   "repository": {
-    "id": 1056452116,
+    "id": "1056452116",
     "url": "https://github.com/karanb192/reddit-mcp-buddy",
     "source": "github"
   },
@@ -20,7 +20,7 @@
     {
       "registry_type": "npm",
       "identifier": "reddit-mcp-buddy",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -27,7 +27,7 @@ import {
 
 // Server metadata
 export const SERVER_NAME = 'reddit-mcp-buddy';
-export const SERVER_VERSION = '1.1.2';
+export const SERVER_VERSION = '1.1.3';
 
 /**
  * Create MCP server with proper protocol implementation


### PR DESCRIPTION
- Fixed critical issue preventing MCP Registry publication
- Repository ID must be string, not number
- Resolves 'cannot unmarshal number into Go struct' error
- Bump version to 1.1.3