### PR TITLE
fix: enforce defaults with explicit parameter descriptions

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -119,7 +119,7 @@ Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minute
             enum: ['hour', 'day', 'week', 'month', 'year', 'all'],
             description: 'Time range for "top" sort only: "hour", "day", "week", "month", "year", "all"'
           },
-          limit: { type: 'number', description: 'Number of posts to return (1-100, default: 25)' },
+          limit: { type: 'number', description: 'Default 25, range (1-100). Change ONLY IF user specifies.' },
           include_nsfw: { type: 'boolean', description: 'Include adult content posts (default: false)' },
           include_subreddit_info: { type: 'boolean', description: 'Include subreddit metadata like subscriber count and description (default: false)' }
         },
@@ -148,7 +148,7 @@ Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minute
             enum: ['hour', 'day', 'week', 'month', 'year', 'all'],
             description: 'Time range filter: "hour", "day", "week", "month", "year", "all"'
           },
-          limit: { type: 'number', description: 'Number of results (1-100, default: 25)' },
+          limit: { type: 'number', description: 'Default 25, range (1-100). Override ONLY IF user requests.' },
           author: { type: 'string', description: 'Filter by specific username (e.g., "spez")' },
           flair: { type: 'string', description: 'Filter by post flair/tag (e.g., "Discussion", "News")' }
         },
@@ -164,15 +164,15 @@ Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minute
           post_id: { type: 'string', description: 'Reddit post ID (e.g., "abc123"). Can be used alone or with subreddit for better performance' },
           subreddit: { type: 'string', description: 'Optional subreddit name when using post_id. Providing it avoids an extra API call (e.g., "science")' },
           url: { type: 'string', description: 'Full Reddit post URL (e.g., "https://reddit.com/r/science/comments/abc123/...")' },
-          comment_limit: { type: 'number', description: 'Maximum comments to fetch (1-500, default: 20)' },
+          comment_limit: { type: 'number', description: 'Default 20, range (1-500). Change ONLY IF user asks.' },
           comment_sort: {
             type: 'string',
             enum: ['best', 'top', 'new', 'controversial', 'qa'],
             description: 'Comment ordering: "best" (algorithm-ranked), "top" (highest score), "new", "controversial", "qa" (Q&A style). Default: best'
           },
-          comment_depth: { type: 'number', description: 'Levels of nested replies to include (1-10, default: 3)' },
+          comment_depth: { type: 'number', description: 'Default 3, range (1-10). Override ONLY IF user specifies.' },
           extract_links: { type: 'boolean', description: 'Extract all URLs mentioned in post and comments (default: false)' },
-          max_top_comments: { type: 'number', description: 'Number of top comments to return (1-50, default: 5)' }
+          max_top_comments: { type: 'number', description: 'Default 5, range (1-20). Change ONLY IF user requests.' }
         }
       }
     },
@@ -183,14 +183,14 @@ Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minute
         type: 'object',
         properties: {
           username: { type: 'string', description: 'Reddit username without u/ prefix (e.g., "spez", not "u/spez")' },
-          posts_limit: { type: 'number', description: 'Number of recent posts to include (0-100, default: 10)' },
-          comments_limit: { type: 'number', description: 'Number of recent comments to include (0-100, default: 10)' },
+          posts_limit: { type: 'number', description: 'Default 10, range (0-100). Change ONLY IF user specifies.' },
+          comments_limit: { type: 'number', description: 'Default 10, range (0-100). Override ONLY IF user asks.' },
           time_range: {
             type: 'string',
             enum: ['day', 'week', 'month', 'year', 'all'],
             description: 'Period to analyze: "day", "week", "month", "year", "all". Note: "all" returns newest content, others return top-scored content from that period'
           },
-          top_subreddits_limit: { type: 'number', description: 'Number of most-active subreddits to list (1-50, default: 10)' }
+          top_subreddits_limit: { type: 'number', description: 'Default 10, range (1-50). Change ONLY IF user requests.' }
         },
         required: ['username']
       }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,7 +12,7 @@ export const browseSubredditSchema = z.object({
   subreddit: z.string().describe('Subreddit name without r/ prefix. Use specific subreddit (e.g., "technology"), "all" for Reddit-wide posts, or "popular" for trending across default subreddits'),
   sort: z.enum(['hot', 'new', 'top', 'rising', 'controversial']).optional().default('hot'),
   time: z.enum(['hour', 'day', 'week', 'month', 'year', 'all']).optional(),
-  limit: z.number().min(1).max(100).optional().default(25),
+  limit: z.number().min(1).max(100).optional().default(25).describe('Default 25, range (1-100). Change ONLY IF user specifies.'),
   include_nsfw: z.boolean().optional().default(false),
   include_subreddit_info: z.boolean().optional().default(false).describe('Include subreddit metadata like subscriber count and description'),
 });
@@ -22,7 +22,7 @@ export const searchRedditSchema = z.object({
   subreddits: z.array(z.string()).optional().describe('Subreddits to search in (leave empty for all)'),
   sort: z.enum(['relevance', 'hot', 'top', 'new', 'comments']).optional().default('relevance'),
   time: z.enum(['hour', 'day', 'week', 'month', 'year', 'all']).optional().default('all'),
-  limit: z.number().min(1).max(100).optional().default(25),
+  limit: z.number().min(1).max(100).optional().default(25).describe('Default 25, range (1-100). Override ONLY IF user requests.'),
   author: z.string().optional(),
   flair: z.string().optional(),
 });
@@ -31,19 +31,19 @@ export const getPostDetailsSchema = z.object({
   post_id: z.string().optional().describe('Reddit post ID (e.g., "1abc2d3")'),
   subreddit: z.string().optional().describe('Subreddit name (optional with post_id, but more efficient if provided)'),
   url: z.string().optional().describe('Full Reddit URL (alternative to post_id)'),
-  comment_limit: z.number().min(1).max(500).optional().default(20),
+  comment_limit: z.number().min(1).max(500).optional().default(20).describe('Default 20, range (1-500). Change ONLY IF user asks.'),
   comment_sort: z.enum(['best', 'top', 'new', 'controversial', 'qa']).optional().default('best'),
-  comment_depth: z.number().min(1).max(10).optional().default(3),
+  comment_depth: z.number().min(1).max(10).optional().default(3).describe('Default 3, range (1-10). Override ONLY IF user specifies.'),
   extract_links: z.boolean().optional().default(false),
-  max_top_comments: z.number().min(1).max(20).optional().default(5).describe('Maximum top comments to show'),
+  max_top_comments: z.number().min(1).max(20).optional().default(5).describe('Default 5, range (1-20). Change ONLY IF user requests.'),
 });
 
 export const userAnalysisSchema = z.object({
   username: z.string().describe('Reddit username'),
-  posts_limit: z.number().min(0).max(100).optional().default(10).describe('Number of recent posts to include (0-100, default: 10)'),
-  comments_limit: z.number().min(0).max(100).optional().default(10).describe('Number of recent comments to include (0-100, default: 10)'),
+  posts_limit: z.number().min(0).max(100).optional().default(10).describe('Default 10, range (0-100). Change ONLY IF user specifies.'),
+  comments_limit: z.number().min(0).max(100).optional().default(10).describe('Default 10, range (0-100). Override ONLY IF user asks.'),
   time_range: z.enum(['day', 'week', 'month', 'year', 'all']).optional().default('month').describe('Time range for posts/comments (default: month). Note: When set to values other than "all", posts are sorted by top scores within that period. When set to "all", posts are sorted by newest'),
-  top_subreddits_limit: z.number().min(1).max(50).optional().default(10).describe('Number of top subreddits to return (1-50, default: 10)'),
+  top_subreddits_limit: z.number().min(1).max(50).optional().default(10).describe('Default 10, range (1-50). Change ONLY IF user requests.'),
 });
 
 


### PR DESCRIPTION
## Summary
- Updated all limit parameter descriptions to explicitly instruct AI clients to honor defaults
- Fixed duplicate descriptions in both Zod schemas and MCP server definitions

## Problem
Claude Desktop and other AI clients were overriding our default limit of 25 with 15, being conservative about token usage.

## Solution
Changed parameter descriptions from passive format:
- `"Number of posts to return (1-100, default: 25)"`

To explicit instruction format:
- `"Default 25, range (1-100). Change ONLY IF user specifies."`

## Changes Made
1. Updated descriptions in `src/tools/index.ts` (Zod schemas)
2. Updated hardcoded descriptions in `src/mcp-server.ts` (MCP tool definitions)

## Files Changed
- `src/tools/index.ts` - Updated Zod schema descriptions
- `src/mcp-server.ts` - Updated MCP tool definition descriptions

## Testing
- Built and tested locally with HTTP server
- Verified descriptions are now served correctly via MCP protocol
- Confirmed new descriptions appear in tool listings

## Next Steps
After merging this, we should implement proper Zod → JSON Schema conversion to avoid duplicate definitions (tracked separately).

## Test Plan
- [x] Build project successfully
- [x] Start server and verify new descriptions via tools/list
- [x] Test that Claude respects defaults with new descriptions