### PR TITLE
fix: handle empty strings and unresolved templates in .mcpb auth

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1",
   "name": "reddit-mcp-buddy",
   "display_name": "Reddit MCP Buddy",
-  "version": "1.1.6",
+  "version": "1.1.10",
   "description": "Browse Reddit directly in Claude Desktop. Search posts, analyze users, explore communities - no API keys needed.",
   "long_description": "Reddit MCP Buddy brings the entire Reddit ecosystem to Claude Desktop with zero configuration required.\n\n**Key Features:**\n• Browse any subreddit with sorting options (hot, new, top, rising)\n• Search Reddit content across all communities\n• Analyze user profiles with karma and post history\n• Get full post details including comments\n• Understand Reddit culture and terminology\n\n**Why Choose Reddit MCP Buddy:**\n• **No API Keys Required** - Works instantly in anonymous mode\n• **Smart Caching** - Fast responses with intelligent caching\n• **Rate Limit Optimized** - Up to 100 requests/minute with authentication\n• **Clean Data** - Only real Reddit data, no fake metrics\n• **Cross-Platform** - Works on Windows, macOS, and Linux\n\n**Perfect for:**\n• Market research and trend analysis\n• Community sentiment monitoring\n• Content discovery and curation\n• User behavior analysis\n• Real-time discussion tracking",
   "author": {

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -60,11 +60,11 @@ export class AuthManager {
    * Load configuration from environment variables
    */
   private loadFromEnv(): AuthConfig | null {
-    const clientId = process.env.REDDIT_CLIENT_ID;
-    const clientSecret = process.env.REDDIT_CLIENT_SECRET;
-    const username = process.env.REDDIT_USERNAME;
-    const password = process.env.REDDIT_PASSWORD;
-    const userAgent = process.env.REDDIT_USER_AGENT;
+    const clientId = this.cleanEnvVar(process.env.REDDIT_CLIENT_ID);
+    const clientSecret = this.cleanEnvVar(process.env.REDDIT_CLIENT_SECRET);
+    const username = this.cleanEnvVar(process.env.REDDIT_USERNAME);
+    const password = this.cleanEnvVar(process.env.REDDIT_PASSWORD);
+    const userAgent = this.cleanEnvVar(process.env.REDDIT_USER_AGENT);
 
     // Need at least client ID and secret for script apps
     if (!clientId || !clientSecret) {
@@ -78,6 +78,27 @@ export class AuthManager {
       password,
       userAgent: userAgent || 'RedditBuddy/1.0 (by /u/karanb192)'
     };
+  }
+
+  /**
+   * Clean environment variable value
+   * Handles empty strings, undefined, and unresolved template strings
+   */
+  private cleanEnvVar(value: string | undefined): string | undefined {
+    if (!value) return undefined;
+
+    const trimmed = value.trim();
+
+    // Treat empty strings as undefined
+    if (trimmed === '') return undefined;
+
+    // Treat unresolved template strings as undefined
+    // (happens when Claude Desktop doesn't have the config value set)
+    if (trimmed.startsWith('${') && trimmed.endsWith('}')) {
+      return undefined;
+    }
+
+    return trimmed;
   }
 
   /**


### PR DESCRIPTION
## Problem

The .mcpb Desktop Extension was throwing **401 Unauthorized errors** when installed without auth credentials configured, while the npx version worked fine.

**Root cause:** When auth credentials aren't configured in Claude Desktop, the manifest.json template variables are passed as:
- Empty strings (`""`)
- OR literal unresolved templates (`"${user_config.reddit_client_id}"`)

The auth code was trying to authenticate with these invalid values instead of falling back to anonymous mode.

## Solution

Added `cleanEnvVar()` method that properly handles:
1. ✅ Empty strings (`""`) → returns `undefined`
2. ✅ Undefined values → returns `undefined`  
3. ✅ Unresolved templates (`"${user_config.xxx}"`) → returns `undefined`
4. ✅ Valid values → returns trimmed value

When all auth values are filtered out, the code correctly falls back to **anonymous mode (10 req/min)**.

## Changes

### `src/core/auth.ts`
- Added `cleanEnvVar()` private method
- Updated `loadFromEnv()` to use `cleanEnvVar()` for all env vars
- Properly handles Claude Desktop's template variable behavior

### `manifest.json`
- Updated version: 1.1.6 → 1.1.10
- Kept auth config UI (optional credentials for 60/100 req/min)

## Testing

✅ Tested .mcpb installation without auth config
✅ Works in anonymous mode (10 req/min)
✅ No more 401 errors
✅ Auth config UI remains available for users who want higher rate limits

## Impact

Users can now install the Desktop Extension and use it immediately without any configuration, while still having the option to add Reddit credentials for higher rate limits.