### PR TITLE
fix: address Anthropic MCP Directory requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,47 @@ Reddit MCP Buddy supports three authentication levels, each with different rate 
 - Web apps only support app-only mode (60 rpm maximum)
 - For 100 requests/minute, you MUST use a script app with username + password
 
+## Privacy & Data Handling
+
+Reddit MCP Buddy is designed with privacy and transparency in mind. Here's how your data is handled:
+
+### Data Collection
+- **Reddit API Data**: The server fetches public Reddit content (posts, comments, user profiles) through Reddit's official API
+- **No Tracking**: We don't collect, store, or transmit any analytics, telemetry, or usage data
+- **No Third Parties**: All data flows directly between your machine, Reddit's API, and your AI assistant
+
+### Local Storage
+- **Authentication Credentials** (optional):
+  - Stored locally in `~/.reddit-mcp-buddy/auth.json` when using `--auth` CLI setup
+  - Passwords are **never** written to disk - only used in-memory for OAuth token exchange
+  - Environment variables (recommended for Claude Desktop) are never persisted by this server
+- **Cache Data**:
+  - Reddit API responses are temporarily cached in memory to improve performance
+  - Cache size limited to 50MB maximum
+  - All cache data is cleared when the server stops
+  - Can be disabled with `REDDIT_BUDDY_NO_CACHE=true`
+
+### Data Transmission
+- **Reddit API Only**: Your credentials are only sent to Reddit's official OAuth endpoints (`https://oauth.reddit.com` and `https://www.reddit.com`)
+- **No External Services**: No data is sent to any other external services, analytics platforms, or third parties
+- **Local Processing**: All data processing happens locally on your machine
+
+### Security Notes
+- **Read-Only Operations**: All tools are read-only - the server never posts, comments, or modifies any Reddit content
+- **Credential Safety**:
+  - OAuth tokens are stored in memory and refreshed automatically
+  - Client secrets are treated as sensitive and never logged
+  - Use environment variables in Claude Desktop config for maximum security
+- **Open Source**: Full source code is available at https://github.com/karanb192/reddit-mcp-buddy for security auditing
+
+### GDPR & Privacy Compliance
+- **No Personal Data Collection**: We don't collect or process any personal data beyond what's necessary to authenticate with Reddit's API
+- **User Control**: You control all credentials and can delete `~/.reddit-mcp-buddy/auth.json` at any time
+- **Right to Erasure**: Simply delete the auth file or uninstall the server to remove all local data
+
+### Questions or Concerns?
+If you have any privacy questions or concerns, please [open an issue](https://github.com/karanb192/reddit-mcp-buddy/issues) on GitHub.
+
 ## Testing & Development
 
 ### Testing Your Rate Limits

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "0.1",
+  "manifest_version": "0.2",
   "name": "reddit-mcp-buddy",
   "display_name": "Reddit MCP Buddy",
   "version": "1.1.10",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -106,27 +106,32 @@ Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minute
     {
       name: 'browse_subreddit',
       description: 'Fetch posts from a subreddit sorted by your choice (hot/new/top/rising). Returns post list with content, scores, and metadata.',
-      inputSchema: zodToJsonSchema(browseSubredditSchema) as any
+      inputSchema: zodToJsonSchema(browseSubredditSchema) as any,
+      readOnlyHint: true
     },
     {
       name: 'search_reddit',
       description: 'Search for posts across Reddit or specific subreddits. Returns matching posts with content and metadata.',
-      inputSchema: zodToJsonSchema(searchRedditSchema) as any
+      inputSchema: zodToJsonSchema(searchRedditSchema) as any,
+      readOnlyHint: true
     },
     {
       name: 'get_post_details',
       description: 'Fetch a Reddit post with its comments. Requires EITHER url OR post_id. IMPORTANT: When using post_id alone, an extra API call is made to fetch the subreddit first (2 calls total). For better efficiency, always provide the subreddit parameter when known (1 call total).',
-      inputSchema: zodToJsonSchema(getPostDetailsSchema) as any
+      inputSchema: zodToJsonSchema(getPostDetailsSchema) as any,
+      readOnlyHint: true
     },
     {
       name: 'user_analysis',
       description: 'Analyze a Reddit user\'s posting history, karma, and activity patterns. Returns posts, comments, and statistics.',
-      inputSchema: zodToJsonSchema(userAnalysisSchema) as any
+      inputSchema: zodToJsonSchema(userAnalysisSchema) as any,
+      readOnlyHint: true
     },
     {
       name: 'reddit_explain',
       description: 'Get explanations of Reddit terms, slang, and culture. Returns definition, origin, usage, and examples.',
-      inputSchema: zodToJsonSchema(redditExplainSchema) as any
+      inputSchema: zodToJsonSchema(redditExplainSchema) as any,
+      readOnlyHint: true
     }
   ];
   


### PR DESCRIPTION
This commit addresses all three requirements from the Anthropic MCP Review team:

1. Tool metadata: Added readOnlyHint annotations to all tool schemas
   - All 5 tools now explicitly marked as read-only operations
   - Added readOnlyHint: true to browse_subreddit, search_reddit, get_post_details, user_analysis, and reddit_explain

2. Manifest version: Updated manifest.json from 0.1 to 0.2
   - Aligns with current MCP standard as requested

3. Privacy documentation: Added comprehensive "Privacy & Data Handling" section to README
   - Clarifies data collection practices (Reddit API only, no tracking)
   - Documents local storage (auth credentials, cache)
   - Explains data transmission (Reddit API only, no third parties)
   - Includes security notes and GDPR compliance information
   - Added after Authentication section for logical flow

All changes are non-breaking and maintain backward compatibility.