### PR TITLE
fix(cli): resolve Windows ESM URL scheme error in dynamic import

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@
 import { AuthManager } from './core/auth.js';
 import { SERVER_VERSION } from './mcp-server.js';
 import { spawn } from 'child_process';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 import readline from 'readline/promises';
 
@@ -175,10 +175,11 @@ async function startServer() {
   } else {
     // Production mode - run compiled JavaScript
     const serverPath = join(__dirname, 'index.js');
+    const serverUrl = pathToFileURL(serverPath).href;
     
     // Dynamic import to run the server
     try {
-      await import(serverPath);
+      await import(serverUrl);
     } catch (error) {
       console.error('Failed to start server:', error);
       process.exit(1);


### PR DESCRIPTION
Convert absolute paths to file:// URLs for ESM dynamic imports on Windows.
Fixes ERR_UNSUPPORTED_ESM_URL_SCHEME when starting server in production mode.

Tested on Windows 11 with Node.js v22.18.0

Closes #26