### PR TITLE
ci: switch to npm trusted publishers (OIDC), upgrade Node to 24

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -55,8 +55,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -80,18 +80,10 @@ jobs:
       - name: Test NPM publish (dry run)
         run: |
           echo "Testing NPM publish with --dry-run..."
-          if [ -n "$NODE_AUTH_TOKEN" ]; then
-            echo "Using provided NPM token"
-            npm publish --dry-run --access public
-          else
-            echo "No NPM token provided, using npm pack instead"
-            npm pack
-            echo "✅ Package can be built successfully"
-            ls -lh *.tgz
-            rm *.tgz
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm pack
+          echo "✅ Package can be built successfully"
+          ls -lh *.tgz
+          rm *.tgz
 
       - name: Test MCP Publisher installation
         run: |
@@ -173,5 +165,5 @@ jobs:
           echo "- ✅ Desktop extension (.mcpb) built" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📝 Next Steps" >> $GITHUB_STEP_SUMMARY
-          echo "1. Add NPM_TOKEN to GitHub Secrets" >> $GITHUB_STEP_SUMMARY
+          echo "1. Configure npm Trusted Publisher on npmjs.com" >> $GITHUB_STEP_SUMMARY
           echo "2. Create a version tag to trigger actual publishing" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret with [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC-based, tokenless)
- Upgrade all CI workflows from Node 20 → Node 24 (ships with npm 11.x, no extra install needed)
- Clean up `test-publish.yml`: remove token-based dry-run, simplify to `npm pack`

## Why
The `NPM_TOKEN` expired, causing the v1.1.12 publish to fail. Trusted publishers eliminate long-lived tokens entirely — GitHub Actions authenticates with npm via short-lived OIDC tokens. No secrets to rotate, no tokens to expire.

## Manual setup required
Before merging, configure the trusted publisher on npmjs.com:
1. Go to https://www.npmjs.com/package/reddit-mcp-buddy/access
2. Under **Trusted Publishers**, add:
   - **Repository**: `karanb192/reddit-mcp-buddy`
   - **Workflow**: `publish-mcp.yml`
3. Optionally toggle **Require OIDC** to block token-based publishing

## Test plan
- [ ] Configure trusted publisher on npmjs.com (manual step)
- [ ] CI passes with Node 24 (unit tests, test-publish dry-run)
- [ ] After merge: re-run v1.1.12 publish or tag v1.1.13 to verify end-to-end
- [ ] `NPM_TOKEN` secret can be deleted from GitHub repo settings after successful publish