### PR TITLE
fix: MCP registry badge and publish verification

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -117,7 +117,7 @@ jobs:
             echo "✅ Server found in registry, checking version..."
 
             # Extract the latest version from the response
-            LATEST_VERSION=$(echo "$RESPONSE" | python3 -c "import sys, json; data = json.load(sys.stdin); servers = data.get('servers', []); [print(server.get('version', 'unknown')) for server in servers if server.get('_meta', {}).get('io.modelcontextprotocol.registry/official', {}).get('isLatest')]" | head -1)
+            LATEST_VERSION=$(echo "$RESPONSE" | python3 -c "import sys, json; data = json.load(sys.stdin); servers = data.get('servers', []); [print(server.get('server', {}).get('version', 'unknown')) for server in servers if server.get('_meta', {}).get('io.modelcontextprotocol.registry/official', {}).get('isLatest')]" | head -1)
 
             echo "🔍 Latest version in registry: $LATEST_VERSION"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that enables Claude Desktop and other AI assistants to browse Reddit, search posts, and analyze user activity. Clean, fast, and actually works - no API keys required.
 
-[![MCP Registry](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0%2Fservers%3Fsearch%3Dreddit-mcp-buddy&query=%24.servers%5B-1%3A%5D.version&label=MCP%20Registry&color=blue)](https://registry.modelcontextprotocol.io/v0/servers/5677b351-373d-4137-bc58-28f1ba0d105d)
+[![MCP Registry](https://img.shields.io/npm/v/reddit-mcp-buddy?label=MCP%20Registry&color=blue)](https://registry.modelcontextprotocol.io)
 [![npm version](https://img.shields.io/npm/v/reddit-mcp-buddy.svg)](https://www.npmjs.com/package/reddit-mcp-buddy)
 [![npm downloads](https://img.shields.io/npm/dm/reddit-mcp-buddy.svg)](https://www.npmjs.com/package/reddit-mcp-buddy)
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/reddit-mcp-buddy.svg?style=flat&logo=github&color=brightgreen)](https://github.com/karanb192/reddit-mcp-buddy/stargazers)


### PR DESCRIPTION
## Summary
- Fix README badge: shields.io doesn't support JSONPath filter expressions, and the MCP registry API nests version under `server.version` (not top-level). Replaced with npm API query labeled as "MCP Registry" — versions are always published together so this is reliable.
- Fix publish verification script: `server.get('version')` → `server.get('server', {}).get('version')` to match the actual API response structure.

## What was broken
- **Badge**: showed "no result" because `$.servers[-1:].version` fails — version is at `$.servers[*].server.version` and the last entry isn't necessarily the latest
- **Verify step**: failed with "Version mismatch! Published 1.1.12 but registry shows unknown" because it read the wrong JSON path

## Test plan
- [x] Badge renders correctly: "MCP Registry | v1.1.12"
- [x] Verification script returns correct version when run locally
- [ ] Next publish workflow passes the verification step