### PR TITLE
fix: return nested reply comments in getPostDetails

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -270,10 +270,22 @@ export class RedditTools {
       locked: post.locked,
     };
 
-    // Process comments
-    const comments = commentsListing.data.children
-      .filter(child => child.kind === 't1') // Only comments
-      .map(child => child.data);
+    // Recursively flatten the comment tree, including nested replies
+    const flattenComments = (listing: typeof commentsListing): typeof commentsListing.data.children[0]['data'][] => {
+      const result: typeof commentsListing.data.children[0]['data'][] = [];
+      for (const child of listing.data.children) {
+        if (child.kind !== 't1') continue; // skip 'more' objects
+        const comment = child.data;
+        result.push(comment);
+        if (comment.replies && typeof comment.replies !== 'string' && comment.replies.data?.children?.length) {
+          result.push(...flattenComments(comment.replies as typeof commentsListing));
+        }
+      }
+      return result;
+    };
+
+    // Process comments — full tree, not just top-level
+    const comments = flattenComments(commentsListing);
 
     let result: any = {
       post: cleanPost,

--- a/src/types/reddit.types.ts
+++ b/src/types/reddit.types.ts
@@ -35,7 +35,7 @@ export interface RedditComment {
   created_utc: number;
   permalink: string;
   depth: number;
-  replies?: RedditComment[];
+  replies?: RedditListing<RedditComment> | '';
   distinguished?: string;
   is_submitter?: boolean;
   stickied?: boolean;


### PR DESCRIPTION
## Problem

\`get_post_details\` only returned top-level comments, silently dropping all nested replies. A post showing 8 comments in Reddit would return only 4 — the other 4 (all replies) were lost.

There were two bugs:

**1. Wrong type for \`replies\` in \`RedditComment\`**

\`replies\` was typed as \`RedditComment[]\` but Reddit's API actually returns it as a \`RedditListing<RedditComment>\` object — or an empty string \`""\` when there are no replies. The incorrect type made it easy to miss the actual shape at runtime.

**2. Flat read of top-level children only**

The comment processing code did:
\`\`\`typescript
const comments = commentsListing.data.children
  .filter(child => child.kind === 't1')
  .map(child => child.data);
\`\`\`

This reads only the root-level children. Each comment's \`.replies\` field (another \`RedditListing\`) was never traversed, so the full thread was never returned.

## Fix

- **\`src/types/reddit.types.ts\`**: corrected \`replies\` type to \`RedditListing<RedditComment> | ''\`
- **\`src/tools/index.ts\`**: replaced flat filter/map with a recursive \`flattenComments\` helper that walks the full reply tree

The \`comment_depth\` parameter was already being passed correctly to Reddit's API — the fix ensures the response is actually used.

## Testing

Build passes cleanly (\`npm run build\`). Tested against a live thread with known nested replies — full comment tree now returned including OP responses.