### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ claude mcp add --transport stdio reddit-mcp-buddy -s user -- npx -y reddit-mcp-b
 
 Use the NPM method: `npx -y reddit-mcp-buddy`
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/karanb192-reddit-mcp-buddy).
+
 ## What can it do?
 
 Ask your AI assistant to:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/karanb192-reddit-mcp-buddy).