### PR TITLE
fix: split subreddit_postid on last '_' to support subs with underscores

### DIFF
--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -131,8 +131,12 @@ export class RedditAPI {
         throw new Error('Invalid post URL format');
       }
     } else if (postId.includes('_')) {
-      // Format: subreddit_postid (or _postid for short URLs like redd.it)
-      [subreddit, id] = postId.split('_');
+      // Format: subreddit_postid (or _postid for short URLs like redd.it).
+      // Subreddit names can contain `_` (e.g. r/pollinations_ai); Reddit post
+      // ids are alphanumeric, so split on the LAST underscore.
+      const sep = postId.lastIndexOf('_');
+      subreddit = postId.substring(0, sep);
+      id = postId.substring(sep + 1);
 
       // Handle short URLs (redd.it) where subreddit is empty - fall through to lookup
       if (!subreddit) {


### PR DESCRIPTION
## bug
```
Error: Not found - r/pollinations does not exist or is inaccessible
```

## replicate
```js
get_post_details({ subreddit: "pollinations_ai", post_id: "1qmjfsw" })
// or any sub w/ `_` in name: programming_horror, askhistorians_ru, etc
```

`getPost()` in `src/services/reddit-api.ts:125` does `[subreddit, id] = postId.split('_')`. For `pollinations_ai_1qmjfsw`, split returns `['pollinations','ai','1qmjfsw']`, destructure takes first 2 -> `subreddit='pollinations'` (truncated), `id='ai'` (wrong). Reddit post ids are alphanum only, so split on LAST `_` is safe.

## diff
```diff
   } else if (postId.includes('_')) {
-    // Format: subreddit_postid
-    [subreddit, id] = postId.split('_');
+    // subreddit names can contain `_` (e.g. r/pollinations_ai); post ids are
+    // alphanumeric, so split on the LAST underscore.
+    const sep = postId.lastIndexOf('_');
+    subreddit = postId.substring(0, sep);
+    id = postId.substring(sep + 1);
   } else {
```
