### PR TITLE
fix: get_post_details fails for subreddits with underscores

### DIFF
--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -132,7 +132,10 @@ export class RedditAPI {
       }
     } else if (postId.includes('_')) {
       // Format: subreddit_postid (or _postid for short URLs like redd.it)
-      [subreddit, id] = postId.split('_');
+      // Use lastIndexOf to handle subreddits with underscores (e.g. world_news_1abc2d3)
+      const lastUnderscore = postId.lastIndexOf('_');
+      subreddit = postId.substring(0, lastUnderscore);
+      id = postId.substring(lastUnderscore + 1);
 
       // Handle short URLs (redd.it) where subreddit is empty - fall through to lookup
       if (!subreddit) {


### PR DESCRIPTION
## Problem

`get_post_details` returned a 404 for any subreddit whose name contains an underscore (e.g. `r/web_design`, `r/game_development`, `r/personal_finance`). The error was misleading — e.g. for `web_design_1abc2d3`, it would report `r/web does not exist`.

Fixes #50.

## Root Cause

In `src/services/reddit-api.ts`, `getPost()` received a `subreddit_postid` string and split it to extract the two components:

```typescript
// Before
[subreddit, id] = postId.split('_');
```

`String.split('_')` splits on **every** underscore. For `web_design_1abc2d3` this produced `["web", "design", "1abc2d3"]` — destructuring gave `subreddit = "web"` and `id = "design"`. Both wrong.

## Fix

Split on the **last** underscore instead. Reddit post IDs are base36 (alphanumeric only, no underscores), so the last `_` is always the correct separator regardless of the subreddit name.

```typescript
// After
const lastUnderscore = postId.lastIndexOf('_');
subreddit = postId.substring(0, lastUnderscore);
id = postId.substring(lastUnderscore + 1);
```

The short-URL fallback path (`_postid` → empty subreddit → `/api/info` lookup) is unaffected since `lastIndexOf` on `_1abc2d3` still yields `subreddit = ""`.

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Live test: fetched `r/web_design` post via `post_id + subreddit` → `PASS`
- [x] Live test: fetched `r/web_design` post via full URL → `PASS`
- [x] Normal subreddits (no underscore) unaffected