### PR TITLE
chore: bump version to 1.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Clean, LLM-optimized Reddit MCP server. Browse posts, search content, analyze users. No fluff, just Reddit data.",
   "main": "dist/index.js",
   "mcpName": "io.github.karanb192/reddit-mcp-buddy",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.karanb192/reddit-mcp-buddy",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Reddit browser for AI assistants. Browse posts, search content, analyze users. No API keys needed.",
   "author": {
     "name": "Karan Bansal",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "reddit-mcp-buddy",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "transport": {
         "type": "stdio"
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -29,7 +29,7 @@ import {
 
 // Server metadata
 export const SERVER_NAME = 'reddit-mcp-buddy';
-export const SERVER_VERSION = '1.1.12';
+export const SERVER_VERSION = '1.1.13';
 
 // MCP Response validation schemas (per MCP spec)
 const ContentBlockSchema = z.object({


### PR DESCRIPTION
## v1.1.13 Release

### Bug Fixes
- **#51** — `get_post_details` now works for subreddits with underscores (e.g. `r/AI_Agents`, `r/web_design`). Was splitting on first `_` instead of last.
- **#52** — Nested comments are now returned as a tree. `comment_depth` was previously ignored at the output level — replies were fetched but silently dropped. Each comment now has a `replies[]` array; `max_top_comments` controls breadth, `comment_depth` controls depth.