### PR TITLE
fix: correct OIDC audience for MCP registry login

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -85,7 +85,7 @@ jobs:
           ./mcp-publisher --version || echo "Version check failed, continuing..."
 
       - name: Login to MCP Registry
-        run: ./mcp-publisher login github-oidc
+        run: ./mcp-publisher login github-oidc --audience https://registry.modelcontextprotocol.io
 
       - name: Publish to MCP Registry
         run: |


### PR DESCRIPTION
The MCP registry now expects audience `https://registry.modelcontextprotocol.io` but the publisher was requesting `mcp-registry`, causing the v1.1.13 publish to fail with 401.

**Error:** `invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]`

**Fix:** Pass `--audience https://registry.modelcontextprotocol.io` to `mcp-publisher login github-oidc`.