### PR TITLE
fix: skip npm publish if version already exists

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -54,7 +54,14 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view reddit-mcp-buddy version 2>/dev/null || echo "none")
+          if [ "$CURRENT" = "$PUBLISHED" ]; then
+            echo "✅ v$CURRENT already on npm, skipping."
+          else
+            npm publish --access public
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Makes the publish step idempotent — if the version is already on npm, it skips rather than failing. Needed to re-run the workflow for MCP registry publish without the npm step erroring out.