### PR TITLE
feat: add RSS fallback for anonymous browse_subreddit when JSON API is blocked

### DIFF
--- a/docs/build-mcpb-guide.md
+++ b/docs/build-mcpb-guide.md
@@ -1,0 +1,182 @@
+# Building the `.mcpb` Desktop Extension — Windows / macOS / Linux
+
+This guide shows how to build `reddit-mcp-buddy.mcpb` from this codebase. A `.mcpb` ("MCP Bundle") is a **ZIP file** containing the compiled server, its production dependencies, and a `manifest.json` at the root — installable into Claude Desktop with one click, no Node.js required by the end user.
+
+---
+
+## What goes inside the bundle
+
+| Item | Source | Required |
+|---|---|---|
+| `manifest.json` | repo root | ✅ must be at ZIP **root** |
+| `dist/` | `npm run build` output | ✅ |
+| `package.json` | repo root | ✅ |
+| `node_modules/` | production deps only (`--omit=dev`) | ✅ |
+| `assets/` | repo root (icon) | ✅ (manifest references `assets/...png`) |
+| `README.md`, `LICENSE` | repo root | optional |
+
+The end-user's Claude Desktop runs `node dist/index.js` (per `manifest.json` → `server.mcp_config`), so production `node_modules` **must** be bundled.
+
+---
+
+## Prerequisites (all OS)
+
+- **Node.js ≥ 18** and **npm** — check: `node --version`
+- Repo cloned, terminal at repo root (the folder with `package.json`, `manifest.json`, `src/`)
+
+> **Tip — sync the version first.** `manifest.json` `version` should match `package.json` `version`. If they differ, edit `manifest.json` → `"version"` before building.
+
+---
+
+## Step 1 — Build the TypeScript (all OS, identical)
+
+```bash
+npm install
+npm run build
+```
+
+Produces `dist/`. Confirm `dist/index.js` and `dist/cli.js` exist before continuing.
+
+---
+
+## Step 2 — Pack the `.mcpb` (pick ONE method)
+
+### Method A — Official `mcpb` CLI ⭐ Recommended (Windows / macOS / Linux)
+
+Cross-platform, no system `zip` needed, handles the ZIP structure correctly.
+
+```bash
+# Build prod deps into the repo so they get bundled
+npm install --omit=dev
+
+# Pack (uses Anthropic's official bundler; respects .mcpbignore)
+npx @anthropic-ai/mcpb pack . reddit-mcp-buddy.mcpb
+```
+
+Output: `reddit-mcp-buddy.mcpb` in the repo root.
+
+> After packing, restore dev deps for further development: `npm install`
+
+---
+
+### Method B — macOS / Linux (repo bash script)
+
+The repo ships `scripts/build-mcpb.sh`. It builds `dist/` if missing, copies files into a temp dir, installs production deps, and zips. **Requires the `zip` utility.**
+
+```bash
+# Ensure zip is installed:
+#   macOS  -> preinstalled (or: brew install zip)
+#   Debian/Ubuntu -> sudo apt-get install zip
+#   Fedora -> sudo dnf install zip
+
+chmod +x scripts/build-mcpb.sh   # first time only
+./scripts/build-mcpb.sh
+```
+
+Output: `reddit-mcp-buddy.mcpb` with a verification step confirming `manifest.json` is at root.
+
+---
+
+### Method C — Windows (PowerShell, no `zip` needed)
+
+Windows usually lacks the `zip` CLI, so the bash script fails. Use PowerShell's built-in `Compress-Archive` instead. Run this block from the repo root in **PowerShell 7+**:
+
+```powershell
+$ErrorActionPreference = 'Stop'
+$tmp = "bundle-temp"
+if (Test-Path $tmp) { Remove-Item -Recurse -Force $tmp }
+New-Item -ItemType Directory $tmp | Out-Null
+
+# Copy bundle contents
+Copy-Item dist,manifest.json,package.json,README.md,LICENSE -Destination $tmp -Recurse
+Copy-Item assets -Destination $tmp -Recurse
+
+# Install production-only dependencies into the bundle
+Push-Location $tmp
+npm install --omit=dev --silent
+Pop-Location
+
+# Zip it (Compress-Archive puts $tmp\* at the archive ROOT — manifest.json ends up at root, as required)
+if (Test-Path reddit-mcp-buddy.mcpb) { Remove-Item reddit-mcp-buddy.mcpb }
+Compress-Archive -Path "$tmp\*" -DestinationPath reddit-mcp-buddy.zip -Force
+Move-Item reddit-mcp-buddy.zip reddit-mcp-buddy.mcpb
+
+# Clean up
+Remove-Item -Recurse -Force $tmp
+Get-Item reddit-mcp-buddy.mcpb | Select-Object Name,@{n='SizeMB';e={[math]::Round($_.Length/1MB,2)}}
+```
+
+Output: `reddit-mcp-buddy.mcpb` (~9 MB) in the repo root.
+
+> **Alternative on Windows:** Method A (`npx @anthropic-ai/mcpb pack`) also works and is simpler — prefer it if you have network access.
+
+---
+
+## Step 3 — Verify the bundle
+
+`manifest.json` **must** sit at the ZIP root or Claude Desktop rejects it.
+
+**macOS / Linux:**
+```bash
+unzip -l reddit-mcp-buddy.mcpb | grep -E " manifest\.json$| dist/index\.js$"
+```
+
+**Windows (PowerShell):**
+```powershell
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$z = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path reddit-mcp-buddy.mcpb))
+$z.Entries | Where-Object { $_.FullName -in @('manifest.json','dist/index.js') } | Select-Object FullName
+$z.Dispose()
+```
+
+Expect to see `manifest.json` and `dist/index.js`. If `manifest.json` shows under a subfolder, repack (don't zip the parent directory — zip the *contents*).
+
+---
+
+## Step 4 — Install in Claude Desktop
+
+1. Open **Claude Desktop** → **Settings → Extensions**
+2. Drag `reddit-mcp-buddy.mcpb` into the window (or double-click the file)
+3. The config UI appears:
+   - **Leave blank** → anonymous mode (10 req/min)
+   - **Client ID + Secret** → app-only (60 req/min)
+   - **+ Username + Password** → full auth (100 req/min, private-sub access)
+4. Restart Claude Desktop if prompted. Reddit tools are now available.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `zip: command not found` (bash script) | `zip` not installed (common on Windows) | Use Method A or Method C |
+| Claude Desktop "invalid extension / manifest not found" | `manifest.json` not at ZIP root | Repack zipping folder *contents*, not the folder itself |
+| Tools missing after install | `dist/` not built or prod deps absent | Re-run Step 1, then `npm install --omit=dev` before packing |
+| Version looks wrong in Extensions list | `manifest.json` `version` ≠ `package.json` | Sync `manifest.json` version, rebuild |
+| Auth seems ignored / `auth.json` not found on disk | **Store (MSIX) Claude Desktop** sandboxes the filesystem; the extension's `auth.json` is redirected inside the package container | Don't rely on disk inspection — verify auth **behaviorally** in-app (ask Claude for a `browse_subreddit` result and check `data_source: "api"` vs `"rss"`) |
+| Build very large / slow | dev deps leaked into bundle | Ensure `npm install --omit=dev` (not plain `npm install`) when populating the bundle |
+
+---
+
+## Optional — add an npm script
+
+To make the Windows build repeatable, you can add to `package.json` `scripts`:
+
+```json
+"build:mcpb:win": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-mcpb.ps1"
+```
+
+(Then move the Method C PowerShell block into `scripts/build-mcpb.ps1`.) For macOS/Linux, `scripts/build-mcpb.sh` already exists.
+
+---
+
+## Quick reference
+
+```text
+build TypeScript  ->  npm install && npm run build
+pack (any OS)     ->  npm install --omit=dev && npx @anthropic-ai/mcpb pack . reddit-mcp-buddy.mcpb
+pack (mac/linux)  ->  ./scripts/build-mcpb.sh
+pack (windows)    ->  PowerShell Compress-Archive block (Method C)
+verify            ->  manifest.json must be at ZIP root
+install           ->  Claude Desktop > Settings > Extensions > drag .mcpb
+```

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "reddit-mcp-buddy",
   "display_name": "Reddit MCP Buddy",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Browse Reddit directly in Claude Desktop. Search posts, analyze users, explore communities - no API keys needed.",
   "long_description": "Reddit MCP Buddy brings the entire Reddit ecosystem to Claude Desktop with zero configuration required.\n\n**Key Features:**\n• Browse any subreddit with sorting options (hot, new, top, rising)\n• Search Reddit content across all communities\n• Analyze user profiles with karma and post history\n• Get full post details including comments\n• Understand Reddit culture and terminology\n\n**Why Choose Reddit MCP Buddy:**\n• **No API Keys Required** - Works instantly in anonymous mode\n• **Smart Caching** - Fast responses with intelligent caching\n• **Rate Limit Optimized** - Up to 100 requests/minute with authentication\n• **Clean Data** - Only real Reddit data, no fake metrics\n• **Cross-Platform** - Works on Windows, macOS, and Linux\n\n**Perfect for:**\n• Market research and trend analysis\n• Community sentiment monitoring\n• Content discovery and curation\n• User behavior analysis\n• Real-time discussion tracking",
   "author": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc && (chmod +x dist/cli.js 2>/dev/null || true)",
+    "build": "tsc",
+    "postbuild": "node -e \"try{require('fs').chmodSync('dist/cli.js',0o755)}catch(e){}\"",
     "start": "node dist/index.js",
     "start:http": "REDDIT_BUDDY_HTTP=true node dist/index.js",
     "test": "bash tests/test-unit.sh",
@@ -21,6 +22,8 @@
     "test:rate-limit:anon": "node scripts/rate-limit-tester.cjs anonymous 15",
     "test:rate-limit:app": "node scripts/rate-limit-tester.cjs app-only 70",
     "test:rate-limit:auth": "node scripts/rate-limit-tester.cjs auth 120",
+    "build:mcpb": "npm run build && bash scripts/build-mcpb.sh",
+    "build:mcpb:win": "npm run build && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-mcpb.ps1",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build",

--- a/scripts/build-mcpb.ps1
+++ b/scripts/build-mcpb.ps1
@@ -1,0 +1,88 @@
+#!/usr/bin/env pwsh
+# Build script for creating the Claude Desktop Extension (.mcpb file) on Windows.
+# PowerShell equivalent of scripts/build-mcpb.sh — uses Compress-Archive so the
+# `zip` CLI (absent on most Windows installs) is NOT required.
+#
+# Usage (from repository root):
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/build-mcpb.ps1
+#   # or:  npm run build:mcpb:win
+
+$ErrorActionPreference = 'Stop'
+
+# --- Must run from repository root ---
+if (-not (Test-Path 'package.json') -or -not (Test-Path 'src') -or -not (Test-Path 'manifest.json')) {
+    Write-Host "[ERROR] This script must be run from the repository root!" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Current directory: $(Get-Location)"
+    Write-Host "Expected files: package.json, manifest.json, src/"
+    Write-Host "  cd path\to\reddit-mcp-buddy"
+    Write-Host "  pwsh -File scripts/build-mcpb.ps1"
+    exit 1
+}
+
+Write-Host "Building Reddit MCP Buddy Desktop Extension..." -ForegroundColor Cyan
+
+# --- Build TypeScript if dist/ is missing ---
+if (-not (Test-Path 'dist')) {
+    Write-Host "dist/ not found - installing deps and compiling TypeScript..."
+    npm install
+    npm run build
+    if (-not (Test-Path 'dist')) {
+        Write-Host "[ERROR] Build failed - dist/ still missing after 'npm run build'." -ForegroundColor Red
+        Write-Host "Run manually and check for TS errors:  npm install; npm run build"
+        exit 1
+    }
+    Write-Host "TypeScript compilation successful" -ForegroundColor Green
+}
+
+# --- Clean previous artifacts ---
+$tmp = 'bundle-temp'
+if (Test-Path $tmp) { Remove-Item -Recurse -Force $tmp }
+if (Test-Path 'reddit-mcp-buddy.mcpb') { Remove-Item -Force 'reddit-mcp-buddy.mcpb' }
+New-Item -ItemType Directory $tmp | Out-Null
+
+# --- Copy bundle contents (manifest.json must end up at archive root) ---
+Copy-Item dist, manifest.json, package.json -Destination $tmp -Recurse
+Copy-Item assets -Destination $tmp -Recurse
+if (Test-Path 'README.md') { Copy-Item README.md -Destination $tmp }
+if (Test-Path 'LICENSE')   { Copy-Item LICENSE   -Destination $tmp } else { Write-Host "[WARN] LICENSE not found (optional)" -ForegroundColor Yellow }
+
+# --- Install production-only dependencies into the bundle ---
+Write-Host "Installing production dependencies..."
+Push-Location $tmp
+npm install --omit=dev --silent
+Pop-Location
+
+# --- Create the .mcpb (a ZIP). Path "$tmp\*" puts contents at the archive ROOT. ---
+Write-Host "Creating .mcpb bundle..."
+$zip = 'reddit-mcp-buddy.zip'
+if (Test-Path $zip) { Remove-Item -Force $zip }
+Compress-Archive -Path "$tmp\*" -DestinationPath $zip -Force
+Move-Item $zip 'reddit-mcp-buddy.mcpb'
+
+# --- Clean up temp dir ---
+Remove-Item -Recurse -Force $tmp
+
+# --- Verify manifest.json is at the archive root ---
+Write-Host "Verifying bundle structure..."
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$archive = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path 'reddit-mcp-buddy.mcpb'))
+$hasManifest = $archive.Entries | Where-Object { $_.FullName -eq 'manifest.json' }
+$hasEntry    = $archive.Entries | Where-Object { $_.FullName -eq 'dist/index.js' }
+$archive.Dispose()
+
+if (-not $hasManifest) {
+    Write-Host "[ERROR] manifest.json is NOT at the archive root!" -ForegroundColor Red
+    exit 1
+}
+if (-not $hasEntry) {
+    Write-Host "[ERROR] dist/index.js missing from bundle - did the build succeed?" -ForegroundColor Red
+    exit 1
+}
+Write-Host "manifest.json found at root; dist/index.js present" -ForegroundColor Green
+
+# --- Report ---
+$mcpb = Get-Item 'reddit-mcp-buddy.mcpb'
+$sizeMB = [math]::Round($mcpb.Length / 1MB, 2)
+Write-Host "Desktop Extension created successfully!" -ForegroundColor Green
+Write-Host ("  {0}  ({1} MB)" -f $mcpb.Name, $sizeMB)

--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -20,6 +20,14 @@ export interface RedditAPIOptions {
   timeout?: number;
 }
 
+/**
+ * Sentinel for engagement metrics that RSS feeds don't provide.
+ * -1 is unambiguous (real Reddit scores can be negative but never below the
+ * post's own downvotes; num_comments is never negative), so the tools layer
+ * can detect "unknown" and decide how to present it to the LLM.
+ */
+export const RSS_UNKNOWN_SCORE = -1;
+
 export class RedditAPI {
   private auth: AuthManager;
   private rateLimiter: RateLimiter;
@@ -93,15 +101,202 @@ export class RedditAPI {
     // All subreddits use /r/ prefix
     const endpoint = `/r/${subreddit}/${sort}.json`;
 
-    // Make request
-    const data = await this.get<RedditListing<RedditPost>>(
-      `${endpoint}?${params.toString()}`
-    );
+    // Make request, with a credential-free RSS fallback.
+    // Reddit network-blocks the unauthenticated .json API from many IPs
+    // (403 "Blocked" from snooserv) regardless of headers. The public Atom
+    // feed (.rss) still serves without auth, so fall back to it when we have
+    // no token. Authenticated requests go to oauth.reddit.com and don't need this.
+    let data: RedditListing<RedditPost>;
+    try {
+      data = await this.get<RedditListing<RedditPost>>(
+        `${endpoint}?${params.toString()}`
+      );
+      data.data._source = 'api';
+    } catch (error) {
+      if (this.auth.isAuthenticated()) {
+        throw error; // OAuth path should work; don't mask real failures
+      }
+      console.error(`⚠️ Anonymous .json failed (${error instanceof Error ? error.message : error}). Falling back to RSS feed.`);
+      try {
+        data = await this.browseSubredditViaRSS(subreddit, sort, { limit, time });
+      } catch (rssError) {
+        // Surface both failures so the cause is clear
+        throw new Error(
+          `Both the JSON API and the RSS fallback failed for r/${subreddit}. ` +
+          `API: ${error instanceof Error ? error.message : error}. ` +
+          `RSS: ${rssError instanceof Error ? rssError.message : rssError}`
+        );
+      }
+    }
 
     // Cache result
     this.cache.set(cacheKey, data);
-    
+
     return data;
+  }
+
+  /**
+   * Browse a subreddit via Reddit's public Atom (RSS) feed.
+   * Credential-free fallback used when the unauthenticated JSON API is blocked.
+   * NOTE: RSS lacks engagement metrics (score, num_comments, upvote_ratio).
+   */
+  private async browseSubredditViaRSS(
+    subreddit: string,
+    sort: 'hot' | 'new' | 'top' | 'rising' | 'controversial',
+    options: { limit?: number; time?: string } = {}
+  ): Promise<RedditListing<RedditPost>> {
+    const { limit = 25, time } = options;
+
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (time && (sort === 'top' || sort === 'controversial')) {
+      params.append('t', time);
+    }
+
+    const xml = await this.getRSS(`/r/${subreddit}/${sort}/.rss?${params.toString()}`);
+    return this.parseAtomFeed(xml, subreddit);
+  }
+
+  /**
+   * Private: Decode XML/HTML entities found in Atom feed text.
+   */
+  private decodeEntities(text: string): string {
+    return text
+      .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+      .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)))
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&amp;/g, '&'); // must run last
+  }
+
+  /**
+   * Private: Parse a Reddit Atom feed into the same RedditListing<RedditPost>
+   * shape the rest of the pipeline expects. Engagement fields are unknown from
+   * RSS and are left at sentinel values (see RSS_UNKNOWN_SCORE) for the tools
+   * layer to represent to the LLM.
+   */
+  private parseAtomFeed(xml: string, fallbackSubreddit: string): RedditListing<RedditPost> {
+    const children: RedditListing<RedditPost>['data']['children'] = [];
+
+    const entryMatches = xml.match(/<entry>([\s\S]*?)<\/entry>/g) || [];
+    for (const entryXml of entryMatches) {
+      const pick = (tag: string): string | undefined => {
+        const m = entryXml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\/${tag}>`));
+        return m ? m[1].trim() : undefined;
+      };
+
+      const rawId = pick('id') || '';
+      const id = rawId.replace(/^t3_/, '');
+      if (!id) continue;
+
+      const title = this.decodeEntities(pick('title') || '');
+
+      const authorMatch = entryXml.match(/<name>([\s\S]*?)<\/name>/);
+      const author = (authorMatch ? authorMatch[1] : '').replace(/^\/u\//, '').trim() || '[unknown]';
+
+      const linkMatch = entryXml.match(/<link[^>]*href="([^"]+)"/);
+      const permalinkFull = linkMatch ? this.decodeEntities(linkMatch[1]) : '';
+      const permalink = permalinkFull.replace(/^https?:\/\/[^/]+/, '');
+
+      const subMatch = permalinkFull.match(/\/r\/([^/]+)/);
+      const categoryMatch = entryXml.match(/<category[^>]*term="([^"]+)"/);
+      const subreddit = (subMatch?.[1] || categoryMatch?.[1] || fallbackSubreddit).trim();
+
+      const published = pick('published') || pick('updated');
+      const created_utc = published ? Math.floor(Date.parse(published) / 1000) : 0;
+
+      // The decoded content HTML contains the external "[link]" anchor and,
+      // for self-posts, the post body. Extract the outbound URL; if it points
+      // back to the comments page, it's a text post.
+      const contentHtml = this.decodeEntities(pick('content') || '');
+      const outboundMatch = contentHtml.match(/<a href="([^"]+)">\s*\[link\]/);
+      const outboundUrl = outboundMatch ? outboundMatch[1] : '';
+      const is_self = !outboundUrl || outboundUrl.includes('/comments/');
+      const url = is_self ? `https://www.reddit.com${permalink}` : outboundUrl;
+
+      // Self-post body: strip the markdown div, cut at the "submitted by" footer.
+      let selftext: string | undefined;
+      if (is_self) {
+        const bodyMatch = contentHtml.match(/<div class="md">([\s\S]*?)<\/div>/);
+        if (bodyMatch) {
+          // Reddit double-escapes entities inside <content>, so decode again
+          // after stripping the inner HTML tags.
+          selftext = this.decodeEntities(
+            bodyMatch[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+          );
+        }
+      }
+
+      const post: RedditPost = {
+        id,
+        title,
+        author,
+        subreddit,
+        subreddit_name_prefixed: `r/${subreddit}`,
+        score: RSS_UNKNOWN_SCORE,
+        num_comments: RSS_UNKNOWN_SCORE,
+        ups: RSS_UNKNOWN_SCORE,
+        downs: 0,
+        created_utc,
+        url,
+        permalink,
+        is_self,
+        selftext,
+      };
+
+      children.push({ kind: 't3', data: post });
+    }
+
+    return {
+      kind: 'Listing',
+      data: {
+        children,
+        after: null,
+        before: null,
+        _source: 'rss',
+      },
+    };
+  }
+
+  /**
+   * Private: Fetch a Reddit RSS/Atom endpoint and return the raw XML text.
+   * Uses the same rate limiter and timeout as the JSON path.
+   */
+  private async getRSS(endpoint: string): Promise<string> {
+    if (!this.rateLimiter.canMakeRequest()) {
+      throw new Error(this.rateLimiter.getErrorMessage(this.auth.isAuthenticated()));
+    }
+
+    const headers = await this.auth.getHeaders();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        headers,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      this.rateLimiter.recordRequest();
+
+      if (!response.ok) {
+        throw new Error(`RSS feed request failed (${response.status})`);
+      }
+
+      const contentType = (response.headers.get('content-type') || '').toLowerCase();
+      if (contentType.includes('text/html')) {
+        throw new Error('RSS endpoint returned HTML (likely blocked)');
+      }
+
+      return await response.text();
+    } catch (error: any) {
+      clearTimeout(timeoutId);
+      if (error.name === 'AbortError') {
+        throw new Error('RSS feed request timed out');
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { RedditAPI } from '../services/reddit-api.js';
+import { RedditAPI, RSS_UNKNOWN_SCORE } from '../services/reddit-api.js';
 import { ContentProcessor } from '../services/content-processor.js';
 import { RedditListing, RedditPost } from '../types/reddit.types.js';
 
@@ -52,6 +52,28 @@ export const redditExplainSchema = z.object({
 });
 
 /**
+ * Shape RSS-sourced posts for consumption by an LLM.
+ *
+ * Reddit's public Atom feed (used as the credential-free fallback) does not
+ * include engagement metrics — score, num_comments and upvote_ratio are absent.
+ * The API client marks those fields with RSS_UNKNOWN_SCORE; here they are
+ * normalized to null and an explanatory note is attached so the model treats
+ * them as unavailable rather than inferring popularity from placeholder values.
+ */
+function shapeRssPosts(posts: any[]): { posts: any[]; note: string } {
+  const cleaned = posts.map(p => ({
+    ...p,
+    score: p.score === RSS_UNKNOWN_SCORE ? null : p.score,
+    num_comments: p.num_comments === RSS_UNKNOWN_SCORE ? null : p.num_comments,
+    upvote_ratio: p.upvote_ratio ?? null,
+  }));
+  return {
+    posts: cleaned,
+    note: 'Served from Reddit\'s public RSS feed (credential-free fallback used because the JSON API was unavailable). score, num_comments, and upvote_ratio are not provided by RSS and are null — do not infer or estimate popularity from them.',
+  };
+}
+
+/**
  * Tool implementations
  */
 export class RedditTools {
@@ -94,10 +116,21 @@ export class RedditTools {
       link_flair_text: child.data.link_flair_text,
     }));
 
+    const dataSource = listing.data._source ?? 'api';
+
     let result: any = {
       posts,
-      total_posts: posts.length
+      total_posts: posts.length,
+      data_source: dataSource,
     };
+
+    // When data came from the RSS fallback, engagement metrics are unavailable.
+    // Shape them so the LLM doesn't fabricate popularity numbers.
+    if (dataSource === 'rss') {
+      const shaped = shapeRssPosts(posts);
+      result.posts = shaped.posts;
+      result.note = shaped.note;
+    }
 
     // Optionally fetch subreddit info
     if (params.include_subreddit_info) {

--- a/src/types/reddit.types.ts
+++ b/src/types/reddit.types.ts
@@ -91,6 +91,10 @@ export interface RedditListing<T> {
     }>;
     dist?: number;
     modhash?: string;
+    // Origin of the data. 'rss' means it was synthesized from Reddit's
+    // public Atom feed (credential-free fallback) and lacks engagement
+    // metrics like score/num_comments/upvote_ratio.
+    _source?: 'api' | 'rss';
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a credential-free **RSS fallback** to `browse_subreddit` so anonymous mode keeps working when Reddit's unauthenticated JSON API is blocked.

## Problem

Reddit network-blocks the unauthenticated JSON API from many IPs (datacenter/VPN/flagged), returning `403 Blocked` from `Server: snooserv` — the "whoa there, pardner" page — **regardless of User-Agent or headers**. This breaks anonymous mode (the zero-setup path the project advertises) entirely on those IPs.

Verified locally across UA variants:

| Request | Result |
| --- | --- |
| `GET /r/programming/hot.json` (default UA) | `403 Blocked` (HTML) |
| `.json` + `RedditBuddy/1.0` UA | `403 Blocked` |
| `.json` + full browser UA + Accept/Sec-Fetch headers | `403 Blocked` |
| `old.reddit.com/...json` + browser UA | `403 Blocked` |
| **`/r/programming/hot/.rss` + `RedditBuddy/1.0` UA** | **`200 OK`, valid Atom** |

The public Atom (RSS) feed still serves without credentials using the project's existing User-Agent, and honors `sort`, `limit`, and `t` (time) params, plus `r/all`.

## Change

`browse_subreddit` now falls back to the RSS feed when an **anonymous** JSON request fails:

- New `getRSS()` — raw-XML fetch reusing the existing rate limiter and timeout.
- New `parseAtomFeed()` / `decodeEntities()` — a small, dependency-free Atom parser that synthesizes the same `RedditListing<RedditPost>` shape the rest of the pipeline already consumes (handles Reddit's double-escaped entities and link-vs-text post detection).
- New `browseSubredditViaRSS()` — builds the `.rss` endpoint and parses it.
- Fallback wiring in `browseSubreddit()`: try `.json` first; on failure, if **not authenticated**, fall back to RSS. Authenticated requests go to `oauth.reddit.com` and are unaffected — they never trigger the fallback. If both fail, a combined error surfaces both causes.

### Handling missing metrics

RSS does not provide engagement metrics. To avoid the model inferring popularity from placeholder values:

- The API client marks unavailable numeric fields with a sentinel (`RSS_UNKNOWN_SCORE`).
- The tools layer normalizes `score` / `num_comments` / `upvote_ratio` to `null`, adds a `data_source` field (`"api"` or `"rss"`), and attaches an explanatory `note` when data came from RSS.

No new dependencies. Type-checks clean (`npm run typecheck`).

## Example output (RSS fallback)

```json
{
  "data_source": "rss",
  "note": "Served from Reddit's public RSS feed (credential-free fallback ...). score, num_comments, and upvote_ratio are not provided by RSS and are null ...",
  "total_posts": 3,
  "posts": [
    {
      "id": "1tlh5aj",
      "title": "Announcement: We've Updated The Rules, and April Is Finally Over",
      "author": "ChemicalRascal",
      "score": null,
      "num_comments": null,
      "upvote_ratio": null,
      "subreddit": "programming",
      "permalink": "https://reddit.com/r/programming/comments/1tlh5aj/...",
      "is_text_post": true
    }
  ]
}
```

## Testing

- `npm run typecheck` — clean.
- Manual end-to-end on a blocked IP: anonymous `browse_subreddit` for `hot` and `top`+`week`, text and link posts — fallback fires, posts parse correctly, metrics null, note present.
- Authenticated path unchanged (no fallback invoked).

## Scope / known limitations (possible follow-ups)

- Fallback covers **`browse_subreddit`** only. `search_reddit`, `get_post_details`, and `user_analysis` still use the JSON API and will 403 on blocked IPs — RSS equivalents exist (`search.rss`, per-post `/comments/<id>.rss`, `/user/<name>.rss`) and can be added the same way.
- `include_nsfw` cannot filter RSS-sourced posts because RSS exposes no `over_18` flag.
- RSS has no `after` cursor, so the fallback path does not paginate beyond the requested `limit`.

Happy to fold the other tools into this PR or open follow-ups — whichever you prefer.
