### PR TITLE
feat: add RSS fallback for anonymous browse_subreddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,11 @@ Reddit MCP Buddy supports three authentication levels, each with different rate 
 
 | Mode | Rate Limit | Required Credentials | Best For |
 |------|------------|---------------------|----------|
-| **Anonymous** | 10 req/min | None | Testing, light usage |
+| **Anonymous** | 10 req/min* | None | Testing, light usage |
 | **App-Only** | 60 req/min | Client ID + Secret | Regular browsing |
 | **Authenticated** | 100 req/min | All 4 credentials | Heavy usage, automation |
+
+*\*Server-side cap. Anonymous requests are served from Reddit's logged-out RSS feed, which applies its own stricter per-IP throttle (often one uncached request per 25-60 seconds). The 15-minute cache and automatic retries absorb much of this, but sustained anonymous browsing is effectively slower than 10 req/min.*
 
 #### How It Works:
 - **Anonymous Mode**: Default mode, no setup required. Only `browse_subreddit` (plus the offline `reddit_explain`) works: Reddit blocks the logged-out JSON API, so browse results come from Reddit's public RSS feed (`data_source: "rss"`) with engagement metrics and NSFW flags as `null`. The remaining tools require credentials.
@@ -359,7 +361,7 @@ cd reddit-mcp-buddy
 | App-only | 60 | 5 min | Client ID + Secret |
 | Authenticated | 100 | 5 min | All credentials |
 
-*Cache TTL applies to subreddit listings. Post details (10 min), search results (10 min), and user profiles (15 min) use fixed TTLs in all modes.*
+*Cache TTL applies to subreddit listings. Post details (10 min), search results (10 min), and user profiles (15 min) use fixed TTLs in all modes. Anonymous throughput is additionally bounded by Reddit's own per-IP RSS throttle, which is stricter than 10/min for uncached requests.*
 
 ## Why Reddit MCP Buddy?
 
@@ -435,7 +437,7 @@ $(npm prefix -g)/bin/reddit-mcp-buddy
 - Solution: Add Reddit credentials (see [Authentication](#authentication-optional))
 
 **Rate limit errors**
-- Without auth: Limited to 10 requests/minute
+- Without auth: 10 requests/minute server cap, and Reddit's own RSS feed throttles harder per IP (the server retries automatically)
 - With app credentials only: 60 requests/minute
 - With full authentication: 100 requests/minute
 - Solution: Add Reddit credentials (see [Authentication](#authentication-optional))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Reddit Browser for Claude Desktop and AI Assistants
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that enables Claude Desktop and other AI assistants to browse Reddit, search posts, and analyze user activity. Clean, fast, and actually works - no API keys required.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that enables Claude Desktop and other AI assistants to browse Reddit, search posts, and analyze user activity. Clean, fast, and actually works - browse subreddits with no API keys; add free Reddit credentials for search, comments, user analysis, and full metrics.
 
 [![MCP Registry](https://img.shields.io/npm/v/reddit-mcp-buddy?label=MCP%20Registry&color=blue)](https://registry.modelcontextprotocol.io)
 [![npm version](https://img.shields.io/npm/v/reddit-mcp-buddy.svg)](https://www.npmjs.com/package/reddit-mcp-buddy)
@@ -40,7 +40,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that en
 
 ## What makes Reddit MCP Buddy different?
 
-- **🚀 Zero setup** - Works instantly, no Reddit API registration needed
+- **🚀 Zero setup** - Browse subreddits instantly, no Reddit API registration needed (search, comments, user analysis, and engagement metrics need free credentials)
 - **⚡ Up to 10x more requests** - Three-tier authentication system (10/60/100 requests per minute)
 - **🎯 Clean data** - No fake "sentiment analysis" or made-up metrics
 - **🧠 LLM-optimized** - Built specifically for AI assistants like Claude
@@ -103,8 +103,10 @@ Browse posts from any subreddit with sorting options.
   - Any specific subreddit (e.g., "technology", "programming", "science")
 - Sort by: hot, new, top, rising, controversial
 - Time range: hour, day, week, month, year, all (for top/controversial sort)
-- Include subreddit info: Optional flag for subreddit metadata
+- Include subreddit info: Optional flag for subreddit metadata (requires credentials)
 ```
+
+> **No credentials?** Results are served from Reddit's public RSS feed (`data_source: "rss"`): `score`, `num_comments`, `upvote_ratio`, and `nsfw` come back `null`, and the `include_nsfw` filter can't be applied. Add credentials ([Authentication](#authentication-optional)) for full data via the API.
 
 ### `search_reddit`
 Search across Reddit or specific subreddits.
@@ -192,7 +194,7 @@ Reddit MCP Buddy supports three authentication levels, each with different rate 
 | **Authenticated** | 100 req/min | All 4 credentials | Heavy usage, automation |
 
 #### How It Works:
-- **Anonymous Mode**: Default mode, no setup required, uses public Reddit API
+- **Anonymous Mode**: Default mode, no setup required. Only `browse_subreddit` works — Reddit blocks the logged-out JSON API, so results come from Reddit's public RSS feed (`data_source: "rss"`) with engagement metrics and NSFW flags as `null`. Other tools require credentials.
 - **App-Only Mode**: Uses OAuth2 client credentials grant (works with both script and web apps)
 - **Authenticated Mode**: Uses OAuth2 password grant (requires script app type)
 
@@ -420,6 +422,11 @@ npm --version
 # Try with full npx path
 $(npm bin -g)/reddit-mcp-buddy
 ```
+
+**Browsing works but search / comments / user analysis fail**
+- Without credentials only `browse_subreddit` works, served from Reddit's public RSS feed (no scores or comment counts)
+- Anonymous browsing can also hit Reddit's own RSS rate limit (HTTP 429)
+- Solution: Add Reddit credentials (see [Authentication](#authentication-optional))
 
 **Rate limit errors**
 - Without auth: Limited to 10 requests/minute

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that enables Claude Desktop and other AI assistants to browse Reddit, search posts, and analyze user activity. Clean, fast, and actually works - browse subreddits with no API keys; add free Reddit credentials for search, comments, user analysis, and full metrics.
 
-[![MCP Registry](https://img.shields.io/npm/v/reddit-mcp-buddy?label=MCP%20Registry&color=blue)](https://registry.modelcontextprotocol.io)
 [![npm version](https://img.shields.io/npm/v/reddit-mcp-buddy.svg)](https://www.npmjs.com/package/reddit-mcp-buddy)
 [![npm downloads](https://img.shields.io/npm/dm/reddit-mcp-buddy.svg)](https://www.npmjs.com/package/reddit-mcp-buddy)
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/reddit-mcp-buddy.svg?style=flat&logo=github&color=brightgreen)](https://github.com/karanb192/reddit-mcp-buddy/stargazers)
@@ -22,7 +21,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that en
 
 ## Table of Contents
 
-- [What makes Reddit MCP Buddy different?](#what-makes-reddit-buddy-different)
+- [What makes Reddit MCP Buddy different?](#what-makes-reddit-mcp-buddy-different)
 - [Quick Start](#quick-start-30-seconds)
 - [What can it do?](#what-can-it-do)
 - [Available Tools](#available-tools)
@@ -194,7 +193,7 @@ Reddit MCP Buddy supports three authentication levels, each with different rate 
 | **Authenticated** | 100 req/min | All 4 credentials | Heavy usage, automation |
 
 #### How It Works:
-- **Anonymous Mode**: Default mode, no setup required. Only `browse_subreddit` works — Reddit blocks the logged-out JSON API, so results come from Reddit's public RSS feed (`data_source: "rss"`) with engagement metrics and NSFW flags as `null`. Other tools require credentials.
+- **Anonymous Mode**: Default mode, no setup required. Only `browse_subreddit` (plus the offline `reddit_explain`) works: Reddit blocks the logged-out JSON API, so browse results come from Reddit's public RSS feed (`data_source: "rss"`) with engagement metrics and NSFW flags as `null`. The remaining tools require credentials.
 - **App-Only Mode**: Uses OAuth2 client credentials grant (works with both script and web apps)
 - **Authenticated Mode**: Uses OAuth2 password grant (requires script app type)
 
@@ -231,7 +230,7 @@ Reddit MCP Buddy is designed with privacy and transparency in mind. Here's how y
 ### Security Notes
 - **Read-Only Operations**: All tools are read-only - the server never posts, comments, or modifies any Reddit content
 - **Credential Safety**:
-  - OAuth tokens are stored in memory and refreshed automatically
+  - OAuth tokens are refreshed automatically and kept in memory; only `--auth` CLI setups also cache the token in `~/.reddit-mcp-buddy/auth.json` (file mode 600)
   - Client secrets are treated as sensitive and never logged
   - Use environment variables in Claude Desktop config for maximum security
 - **Open Source**: Full source code is available at https://github.com/karanb192/reddit-mcp-buddy for security auditing
@@ -294,6 +293,8 @@ REDDIT_BUDDY_PORT=8080 npx -y reddit-mcp-buddy --http
 
 **Note:** The server runs in stdio mode by default (for Claude Desktop). Use `--http` flag for testing with Postman MCP or direct API calls.
 
+## Installation Options
+
 ### Global Install
 ```bash
 npm install -g reddit-mcp-buddy
@@ -311,7 +312,10 @@ npm link
 
 ### Using Docker
 ```bash
-docker run -it karanb192/reddit-mcp-buddy
+git clone https://github.com/karanb192/reddit-mcp-buddy.git
+cd reddit-mcp-buddy
+docker build -t reddit-mcp-buddy .
+docker run -it reddit-mcp-buddy
 ```
 
 ### Claude Desktop Extension
@@ -331,13 +335,13 @@ cd reddit-mcp-buddy
 ./scripts/build-mcpb.sh
 ```
 
-**Note**: The Desktop Extension format is currently in preview (September 2025). Most users should use the standard npm installation method shown in [Quick Start](#quick-start-30-seconds).
+**Note**: Most users should use the standard npm installation method shown in [Quick Start](#quick-start-30-seconds).
 
 ## Comparison with Other Tools
 
 | Feature | Reddit MCP Buddy | Other MCP Tools |
 |---------|-------------|----------------|
-| **Zero Setup** | ✅ Works instantly | ❌ Requires API keys |
+| **Zero Setup** | ✅ Browse instantly; free keys unlock the rest | ❌ Keys required for everything |
 | **Max Rate Limit** | ✅ 100 req/min proven | ❓ Unverified claims |
 | **Language** | TypeScript/Node.js | Python (most) |
 | **Tools Count** | 5 (focused) | 8-10 (redundant) |
@@ -354,6 +358,8 @@ cd reddit-mcp-buddy
 | Anonymous | 10 | 15 min | None |
 | App-only | 60 | 5 min | Client ID + Secret |
 | Authenticated | 100 | 5 min | All credentials |
+
+*Cache TTL applies to subreddit listings. Post details (10 min), search results (10 min), and user profiles (15 min) use fixed TTLs in all modes.*
 
 ## Why Reddit MCP Buddy?
 
@@ -419,13 +425,13 @@ cd reddit-mcp-buddy
 node --version
 npm --version
 
-# Try with full npx path
-$(npm bin -g)/reddit-mcp-buddy
+# Try the full global-bin path
+$(npm prefix -g)/bin/reddit-mcp-buddy
 ```
 
 **Browsing works but search / comments / user analysis fail**
-- Without credentials only `browse_subreddit` works, served from Reddit's public RSS feed (no scores or comment counts)
-- Anonymous browsing can also hit Reddit's own RSS rate limit (HTTP 429)
+- Without credentials only `browse_subreddit` (served from Reddit's public RSS feed, no scores or comment counts) and the offline `reddit_explain` work
+- Anonymous browsing can also hit Reddit's own RSS rate limit (HTTP 429); the server retries automatically, but sustained throttling can still fail
 - Solution: Add Reddit credentials (see [Authentication](#authentication-optional))
 
 **Rate limit errors**
@@ -453,7 +459,7 @@ $(npm bin -g)/reddit-mcp-buddy
 | `REDDIT_CLIENT_SECRET` | Reddit app secret | No | 60 req/min (with ID) |
 | `REDDIT_USERNAME` | Reddit account username | No | 100 req/min (with all 4) |
 | `REDDIT_PASSWORD` | Reddit account password | No | 100 req/min (with all 4) |
-| `REDDIT_USER_AGENT` | User agent string | No | - |
+| `REDDIT_USER_AGENT` | Custom user agent string (applies when credentials are configured) | No | - |
 
 #### Server Configuration
 | Variable | Description | Default |
@@ -469,7 +475,7 @@ $(npm bin -g)/reddit-mcp-buddy
 Reddit MCP Buddy includes intelligent caching to improve performance and reduce API calls:
 
 - **Memory Safe**: Hard limit of 50MB - won't affect your system performance
-- **Adaptive TTLs**: Hot posts (5min), New posts (2min), Top posts (30min)
+- **Per-Content TTLs**: Post details (10min), user profiles (15min), search results (10min); subreddit listings use the mode default (15min anonymous, 5min with credentials)
 - **LRU Eviction**: Automatically removes least-used data when approaching limits
 - **Hit Tracking**: Optimizes cache based on actual usage patterns
 
@@ -530,13 +536,13 @@ We keep things simple:
 
 ### Official MCP Resources
 - **[MCP Registry](https://registry.modelcontextprotocol.io)** - Official registry of MCP servers
-- **[MCP Specification](https://spec.modelcontextprotocol.io)** - Official Model Context Protocol specification
+- **[MCP Specification](https://modelcontextprotocol.io/specification/latest)** - Official Model Context Protocol specification
 - **[MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)** - SDK used to build this server
 - **[MCP Servers Repository](https://github.com/modelcontextprotocol/servers)** - Collection of official MCP server implementations
-- **[Awesome MCP Servers](https://github.com/modelcontextprotocol/awesome-mcp-servers)** - Community-curated list of MCP servers
+- **[Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers)** - Community-curated list of MCP servers
 
 ### Where to Find This Server
-- **[MCP Registry Direct Link](https://registry.modelcontextprotocol.io/v0/servers/5677b351-373d-4137-bc58-28f1ba0d105d)** - Direct API link to this server
+- **[MCP Registry API Link](https://registry.modelcontextprotocol.io/v0/servers?search=reddit-mcp-buddy)** - Direct API query for this server
 - **[MCP Registry Search](https://registry.modelcontextprotocol.io)** - Search for "reddit" to find all versions
 - **[NPM Package](https://www.npmjs.com/package/reddit-mcp-buddy)** - Install via npm/npx
 - **[GitHub Repository](https://github.com/karanb192/reddit-mcp-buddy)** - Source code and issues
@@ -546,9 +552,9 @@ We keep things simple:
 # Get all versions of reddit-mcp-buddy from the registry
 curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=reddit-mcp-buddy" | jq
 
-# Get just version numbers and UUIDs
+# Get just names, version numbers, and latest flag
 curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=reddit-mcp-buddy" | \
-  jq '.servers[] | {version, id: ._meta."io.modelcontextprotocol.registry/official".id}'
+  jq '.servers[] | {name: .server.name, version: .server.version, isLatest: ._meta."io.modelcontextprotocol.registry/official".isLatest}'
 ```
 
 ## License

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.karanb192/reddit-mcp-buddy",
   "version": "1.1.13",
-  "description": "Reddit browser for AI assistants. Browse posts, search content, analyze users. No API keys needed.",
+  "description": "Reddit browser for AI assistants. Browse posts without API keys; add Reddit credentials to also search, read comments, and analyze users.",
   "author": {
     "name": "Karan Bansal",
     "email": "karanb192@gmail.com",

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -30,6 +30,10 @@ const OAuthTokenResponseSchema = z.object({
 export class AuthManager {
   private config: AuthConfig | null = null;
   private configPath: string;
+  // True when credentials came from environment variables. Env-supplied
+  // credentials are never persisted to auth.json — only the --auth
+  // interactive setup (which never calls load()) opts into disk storage.
+  private configFromEnv = false;
   // Lock for token refresh to prevent concurrent refresh attempts (race conditions)
   private tokenRefreshPromise: Promise<void> | null = null;
   // Token expiration buffer (refresh 10 seconds before actual expiration to handle clock drift)
@@ -47,6 +51,7 @@ export class AuthManager {
     const envConfig = this.loadFromEnv();
     if (envConfig) {
       this.config = envConfig;
+      this.configFromEnv = true;
       return this.config;
     }
 
@@ -333,12 +338,17 @@ export class AuthManager {
       this.config.expiresAt = expiresAt;
       this.config.scope = data.scope;
 
-      // Never save password to disk
-      const configToSave = { ...this.config };
-      delete configToSave.password;
+      // Persist the refreshed token only for file-based (--auth) setups.
+      // Env-supplied credentials stay in memory: writing them to auth.json
+      // would break the documented "env vars are never persisted" contract.
+      if (!this.configFromEnv) {
+        // Never save password to disk
+        const configToSave = { ...this.config };
+        delete configToSave.password;
 
-      // Save updated config
-      await this.save(configToSave);
+        // Save updated config
+        await this.save(configToSave);
+      }
     } catch (error) {
       throw new Error(`Failed to refresh access token: ${error}`);
     }
@@ -363,7 +373,7 @@ export class AuthManager {
    */
   async getHeaders(): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
-      'User-Agent': 'RedditBuddy/1.0 (by /u/karanb192)',
+      'User-Agent': this.config?.userAgent || 'RedditBuddy/1.0 (by /u/karanb192)',
       'Accept': 'application/json',
       'Accept-Language': 'en-US,en;q=0.9',
       'Cache-Control': 'no-cache'

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -198,7 +198,7 @@ Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minute
   const toolDefinitions: Tool[] = [
     {
       name: 'browse_subreddit',
-      description: 'Fetch posts from a subreddit sorted by your choice (hot/new/top/rising). Returns post list with content, scores, and metadata.',
+      description: 'Fetch posts from a subreddit sorted by your choice (hot/new/top/rising/controversial). Returns a post list with content, metadata, and a data_source field. With Reddit credentials (data_source "api") posts include score, num_comments, and upvote_ratio; without credentials, results come from Reddit\'s public RSS feed (data_source "rss") and those fields plus nsfw are null — see the response note and do not infer popularity from them.',
       inputSchema: zodSchemaToMCPInputSchema(browseSubredditSchema, 'browse_subreddit'),
       readOnlyHint: true
     },

--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -20,6 +20,14 @@ export interface RedditAPIOptions {
   timeout?: number;
 }
 
+/**
+ * Sentinel for engagement metrics that RSS feeds don't provide.
+ * -1 is unambiguous (real Reddit scores can be negative but never below the
+ * post's own downvotes; num_comments is never negative), so the tools layer
+ * can detect "unknown" and decide how to present it to the LLM.
+ */
+export const RSS_UNKNOWN_SCORE = -1;
+
 export class RedditAPI {
   private auth: AuthManager;
   private rateLimiter: RateLimiter;
@@ -93,15 +101,202 @@ export class RedditAPI {
     // All subreddits use /r/ prefix
     const endpoint = `/r/${subreddit}/${sort}.json`;
 
-    // Make request
-    const data = await this.get<RedditListing<RedditPost>>(
-      `${endpoint}?${params.toString()}`
-    );
+    // Make request, with a credential-free RSS fallback.
+    // Reddit network-blocks the unauthenticated .json API from many IPs
+    // (403 "Blocked" from snooserv) regardless of headers. The public Atom
+    // feed (.rss) still serves without auth, so fall back to it when we have
+    // no token. Authenticated requests go to oauth.reddit.com and don't need this.
+    let data: RedditListing<RedditPost>;
+    try {
+      data = await this.get<RedditListing<RedditPost>>(
+        `${endpoint}?${params.toString()}`
+      );
+      data.data._source = 'api';
+    } catch (error) {
+      if (this.auth.isAuthenticated()) {
+        throw error; // OAuth path should work; don't mask real failures
+      }
+      console.error(`⚠️ Anonymous .json failed (${error instanceof Error ? error.message : error}). Falling back to RSS feed.`);
+      try {
+        data = await this.browseSubredditViaRSS(subreddit, sort, { limit, time });
+      } catch (rssError) {
+        // Surface both failures so the cause is clear
+        throw new Error(
+          `Both the JSON API and the RSS fallback failed for r/${subreddit}. ` +
+          `API: ${error instanceof Error ? error.message : error}. ` +
+          `RSS: ${rssError instanceof Error ? rssError.message : rssError}`
+        );
+      }
+    }
 
     // Cache result
     this.cache.set(cacheKey, data);
-    
+
     return data;
+  }
+
+  /**
+   * Browse a subreddit via Reddit's public Atom (RSS) feed.
+   * Credential-free fallback used when the unauthenticated JSON API is blocked.
+   * NOTE: RSS lacks engagement metrics (score, num_comments, upvote_ratio).
+   */
+  private async browseSubredditViaRSS(
+    subreddit: string,
+    sort: 'hot' | 'new' | 'top' | 'rising' | 'controversial',
+    options: { limit?: number; time?: string } = {}
+  ): Promise<RedditListing<RedditPost>> {
+    const { limit = 25, time } = options;
+
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (time && (sort === 'top' || sort === 'controversial')) {
+      params.append('t', time);
+    }
+
+    const xml = await this.getRSS(`/r/${subreddit}/${sort}/.rss?${params.toString()}`);
+    return this.parseAtomFeed(xml, subreddit);
+  }
+
+  /**
+   * Private: Decode XML/HTML entities found in Atom feed text.
+   */
+  private decodeEntities(text: string): string {
+    return text
+      .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+      .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)))
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&amp;/g, '&'); // must run last
+  }
+
+  /**
+   * Private: Parse a Reddit Atom feed into the same RedditListing<RedditPost>
+   * shape the rest of the pipeline expects. Engagement fields are unknown from
+   * RSS and are left at sentinel values (see RSS_UNKNOWN_SCORE) for the tools
+   * layer to represent to the LLM.
+   */
+  private parseAtomFeed(xml: string, fallbackSubreddit: string): RedditListing<RedditPost> {
+    const children: RedditListing<RedditPost>['data']['children'] = [];
+
+    const entryMatches = xml.match(/<entry>([\s\S]*?)<\/entry>/g) || [];
+    for (const entryXml of entryMatches) {
+      const pick = (tag: string): string | undefined => {
+        const m = entryXml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\/${tag}>`));
+        return m ? m[1].trim() : undefined;
+      };
+
+      const rawId = pick('id') || '';
+      const id = rawId.replace(/^t3_/, '');
+      if (!id) continue;
+
+      const title = this.decodeEntities(pick('title') || '');
+
+      const authorMatch = entryXml.match(/<name>([\s\S]*?)<\/name>/);
+      const author = (authorMatch ? authorMatch[1] : '').replace(/^\/u\//, '').trim() || '[unknown]';
+
+      const linkMatch = entryXml.match(/<link[^>]*href="([^"]+)"/);
+      const permalinkFull = linkMatch ? this.decodeEntities(linkMatch[1]) : '';
+      const permalink = permalinkFull.replace(/^https?:\/\/[^/]+/, '');
+
+      const subMatch = permalinkFull.match(/\/r\/([^/]+)/);
+      const categoryMatch = entryXml.match(/<category[^>]*term="([^"]+)"/);
+      const subreddit = (subMatch?.[1] || categoryMatch?.[1] || fallbackSubreddit).trim();
+
+      const published = pick('published') || pick('updated');
+      const created_utc = published ? Math.floor(Date.parse(published) / 1000) : 0;
+
+      // The decoded content HTML contains the external "[link]" anchor and,
+      // for self-posts, the post body. Extract the outbound URL; if it points
+      // back to the comments page, it's a text post.
+      const contentHtml = this.decodeEntities(pick('content') || '');
+      const outboundMatch = contentHtml.match(/<a href="([^"]+)">\s*\[link\]/);
+      const outboundUrl = outboundMatch ? outboundMatch[1] : '';
+      const is_self = !outboundUrl || outboundUrl.includes('/comments/');
+      const url = is_self ? `https://www.reddit.com${permalink}` : outboundUrl;
+
+      // Self-post body: strip the markdown div, cut at the "submitted by" footer.
+      let selftext: string | undefined;
+      if (is_self) {
+        const bodyMatch = contentHtml.match(/<div class="md">([\s\S]*?)<\/div>/);
+        if (bodyMatch) {
+          // Reddit double-escapes entities inside <content>, so decode again
+          // after stripping the inner HTML tags.
+          selftext = this.decodeEntities(
+            bodyMatch[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+          );
+        }
+      }
+
+      const post: RedditPost = {
+        id,
+        title,
+        author,
+        subreddit,
+        subreddit_name_prefixed: `r/${subreddit}`,
+        score: RSS_UNKNOWN_SCORE,
+        num_comments: RSS_UNKNOWN_SCORE,
+        ups: RSS_UNKNOWN_SCORE,
+        downs: 0,
+        created_utc,
+        url,
+        permalink,
+        is_self,
+        selftext,
+      };
+
+      children.push({ kind: 't3', data: post });
+    }
+
+    return {
+      kind: 'Listing',
+      data: {
+        children,
+        after: null,
+        before: null,
+        _source: 'rss',
+      },
+    };
+  }
+
+  /**
+   * Private: Fetch a Reddit RSS/Atom endpoint and return the raw XML text.
+   * Uses the same rate limiter and timeout as the JSON path.
+   */
+  private async getRSS(endpoint: string): Promise<string> {
+    if (!this.rateLimiter.canMakeRequest()) {
+      throw new Error(this.rateLimiter.getErrorMessage(this.auth.isAuthenticated()));
+    }
+
+    const headers = await this.auth.getHeaders();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        headers,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      this.rateLimiter.recordRequest();
+
+      if (!response.ok) {
+        throw new Error(`RSS feed request failed (${response.status})`);
+      }
+
+      const contentType = (response.headers.get('content-type') || '').toLowerCase();
+      if (contentType.includes('text/html')) {
+        throw new Error('RSS endpoint returned HTML (likely blocked)');
+      }
+
+      return await response.text();
+    } catch (error: any) {
+      clearTimeout(timeoutId);
+      if (error.name === 'AbortError') {
+        throw new Error('RSS feed request timed out');
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -45,6 +45,14 @@ export class RedditAPI {
   private readonly MAX_BACKOFF_MS = 30000; // 30 second max backoff
   private readonly INITIAL_BACKOFF_MS = 100;
   private readonly BACKOFF_MULTIPLIER = 2;
+  // Set when the anonymous .json API is proven blocked for this IP: it
+  // returned 403 while the RSS fallback succeeded, so Reddit itself was
+  // reachable and the subreddit is public — the 403 can only be the
+  // IP-level policy block. While active, cache-miss browses skip the doomed
+  // .json probe (saves a rate-limit slot and ~0.5s per call). Time-limited
+  // so a network/IP change heals without a restart.
+  private anonJsonBlockedUntil = 0;
+  private readonly ANON_JSON_BLOCK_TTL_MS = 15 * 60 * 1000;
 
   constructor(options: RedditAPIOptions) {
     this.auth = options.authManager;
@@ -107,25 +115,37 @@ export class RedditAPI {
     // feed (.rss) still serves without auth, so fall back to it when we have
     // no token. Authenticated requests go to oauth.reddit.com and don't need this.
     let data: RedditListing<RedditPost>;
-    try {
-      data = await this.get<RedditListing<RedditPost>>(
-        `${endpoint}?${params.toString()}`
-      );
-      data.data._source = 'api';
-    } catch (error) {
-      if (this.auth.isAuthenticated()) {
-        throw error; // OAuth path should work; don't mask real failures
-      }
-      console.error(`⚠️ Anonymous .json failed (${error instanceof Error ? error.message : error}). Falling back to RSS feed.`);
+    if (!this.auth.isAuthenticated() && Date.now() < this.anonJsonBlockedUntil) {
+      // JSON recently proven blocked — go straight to RSS.
+      data = await this.browseSubredditViaRSS(subreddit, sort, { limit, time });
+    } else {
       try {
-        data = await this.browseSubredditViaRSS(subreddit, sort, { limit, time });
-      } catch (rssError) {
-        // Surface both failures so the cause is clear
-        throw new Error(
-          `Both the JSON API and the RSS fallback failed for r/${subreddit}. ` +
-          `API: ${error instanceof Error ? error.message : error}. ` +
-          `RSS: ${rssError instanceof Error ? rssError.message : rssError}`
+        data = await this.get<RedditListing<RedditPost>>(
+          `${endpoint}?${params.toString()}`
         );
+        data.data._source = 'api';
+      } catch (error) {
+        if (this.auth.isAuthenticated()) {
+          throw error; // OAuth path should work; don't mask real failures
+        }
+        console.error(`⚠️ Anonymous .json failed (${error instanceof Error ? error.message : error}). Falling back to RSS feed.`);
+        try {
+          data = await this.browseSubredditViaRSS(subreddit, sort, { limit, time });
+          // RSS worked while .json failed. Latch the skip only on the
+          // block's signature (403): a transient .json 500/timeout must not
+          // degrade the whole session, and a genuinely private/nonexistent
+          // subreddit can't reach here because its RSS feed fails too.
+          if ((error as { status?: number }).status === 403) {
+            this.anonJsonBlockedUntil = Date.now() + this.ANON_JSON_BLOCK_TTL_MS;
+          }
+        } catch (rssError) {
+          // Surface both failures so the cause is clear
+          throw new Error(
+            `Both the JSON API and the RSS fallback failed for r/${subreddit}. ` +
+            `API: ${error instanceof Error ? error.message : error}. ` +
+            `RSS: ${rssError instanceof Error ? rssError.message : rssError}`
+          );
+        }
       }
     }
 
@@ -152,7 +172,25 @@ export class RedditAPI {
       params.append('t', time);
     }
 
-    const xml = await this.getRSS(`/r/${subreddit}/${sort}/.rss?${params.toString()}`);
+    let xml: string;
+    try {
+      xml = await this.getRSS(`/r/${subreddit}/${sort}/.rss?${params.toString()}`);
+    } catch (error) {
+      // Once the JSON probe is skipped (anonJsonBlockedUntil), these errors
+      // reach the user directly — give them subreddit context instead of a
+      // bare "RSS feed request failed (NNN)".
+      const status = (error as { status?: number }).status;
+      if (status === 404) {
+        throw new Error(`Not found - r/${subreddit} does not exist or is inaccessible`);
+      }
+      if (status === 403) {
+        throw new Error(`Cannot access r/${subreddit} - it may be private, quarantined, or NSFW (Reddit's logged-out feed refuses NSFW subreddits)`);
+      }
+      if (status === 429) {
+        throw new Error(`Reddit rate-limited the RSS feed for r/${subreddit} (HTTP 429) - anonymous access has a small per-IP quota; wait a minute and try again`);
+      }
+      throw error;
+    }
     return this.parseAtomFeed(xml, subreddit);
   }
 
@@ -206,15 +244,24 @@ export class RedditAPI {
       const published = pick('published') || pick('updated');
       const created_utc = published ? Math.floor(Date.parse(published) / 1000) : 0;
 
-      // The decoded content HTML contains the external "[link]" anchor and,
-      // for self-posts, the post body. Extract the outbound URL; if it points
-      // back to the comments page, it's a text post.
+      // The decoded content HTML contains the post body (for self-posts)
+      // followed by Reddit's footer with the "[link]" anchor. Take the LAST
+      // "[link]" anchor: the footer comes after the body, so an anchor a
+      // self-post author crafted inside their own text can't shadow it.
       const contentHtml = this.decodeEntities(pick('content') || '');
-      const outboundMatch = contentHtml.match(/<a href="([^"]+)">\s*\[link\]/);
+      const linkAnchors = [...contentHtml.matchAll(/<a href="([^"]+)">\s*\[link\]/g)];
+      const outboundMatch = linkAnchors.length > 0 ? linkAnchors[linkAnchors.length - 1] : null;
       // Reddit double-escapes entities inside <content>, so the extracted href
       // needs a second decode (?a=1&amp;b=2 -> ?a=1&b=2), same as selftext below.
       const outboundUrl = outboundMatch ? this.decodeEntities(outboundMatch[1]) : '';
-      const is_self = !outboundUrl || outboundUrl.includes('/comments/');
+      // Self-posts' [link] anchor points back at the post's OWN page, so
+      // compare paths instead of matching any '/comments/' substring — link
+      // posts that target other Reddit threads (r/bestof, crossposts) must
+      // keep their real outbound URL.
+      const asPath = (u: string): string =>
+        u.replace(/^https?:\/\/[^/]+/, '').replace(/[?#].*$/, '').replace(/\/+$/, '');
+      const is_self =
+        !outboundUrl || (permalink !== '' && asPath(outboundUrl) === asPath(permalink));
       const url = is_self ? `https://www.reddit.com${permalink}` : outboundUrl;
 
       // Self-post body: strip the markdown div, cut at the "submitted by" footer.
@@ -265,7 +312,7 @@ export class RedditAPI {
    * Private: Fetch a Reddit RSS/Atom endpoint and return the raw XML text.
    * Uses the same rate limiter and timeout as the JSON path.
    */
-  private async getRSS(endpoint: string): Promise<string> {
+  private async getRSS(endpoint: string, retries: number = 2): Promise<string> {
     if (!this.rateLimiter.canMakeRequest()) {
       throw new Error(this.rateLimiter.getErrorMessage(this.auth.isAuthenticated()));
     }
@@ -282,8 +329,21 @@ export class RedditAPI {
       clearTimeout(timeoutId);
       this.rateLimiter.recordRequest();
 
+      // Reddit throttles the logged-out feed per-IP in short windows
+      // (~25-60s, advertised via Retry-After / x-ratelimit-reset). Retry
+      // transient failures like the JSON path does, honoring the server's
+      // requested wait.
+      if ((response.status === 429 || response.status === 503) && retries > 0) {
+        const waitMs =
+          this.getRetryAfterDelay(response) ??
+          this.getRateLimitResetDelay(response) ??
+          this.calculateBackoff(retries);
+        await new Promise(resolve => setTimeout(resolve, waitMs));
+        return this.getRSS(endpoint, retries - 1);
+      }
+
       if (!response.ok) {
-        throw new Error(`RSS feed request failed (${response.status})`);
+        throw this.httpError(`RSS feed request failed (${response.status})`, response.status);
       }
 
       const contentType = (response.headers.get('content-type') || '').toLowerCase();
@@ -545,6 +605,17 @@ export class RedditAPI {
   }
 
   /**
+   * Private: Error carrying the HTTP status that caused it, so callers can
+   * distinguish failure classes (e.g. the anonymous 403 IP-block) without
+   * parsing message text.
+   */
+  private httpError(message: string, status: number): Error {
+    const err: Error & { status?: number } = new Error(message);
+    err.status = status;
+    return err;
+  }
+
+  /**
    * Private: Calculate exponential backoff with jitter
    */
   private calculateBackoff(retriesLeft: number): number {
@@ -586,6 +657,20 @@ export class RedditAPI {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Private: Delay until the rate-limit window resets, from Reddit's
+   * x-ratelimit-reset header (seconds until reset). The logged-out .rss
+   * endpoint sends this on 429s where Retry-After may be absent.
+   */
+  private getRateLimitResetDelay(response: Response): number | null {
+    const reset = response.headers.get('x-ratelimit-reset');
+    if (!reset) return null;
+    const seconds = parseFloat(reset);
+    if (isNaN(seconds) || seconds < 0) return null;
+    // +1s cushion so the retry lands inside the next window
+    return Math.min((seconds + 1) * 1000, this.MAX_BACKOFF_MS);
   }
 
   /**
@@ -693,34 +778,34 @@ export class RedditAPI {
           // Extract subreddit name from URL if possible
           const subredditMatch = endpoint.match(/\/r\/([^\/]+)/);
           const subredditName = subredditMatch ? subredditMatch[1] : 'resource';
-          throw new Error(`Not found - r/${subredditName} does not exist or is inaccessible`);
+          throw this.httpError(`Not found - r/${subredditName} does not exist or is inaccessible`, 404);
         }
         if (response.status === 403) {
           // For 403, try to determine if it's a non-existent subreddit or private
           const subredditMatch = endpoint.match(/\/r\/([^\/]+)/);
           const subredditName = subredditMatch ? subredditMatch[1] : null;
-          
+
           if (subredditName) {
             // Common issue: Reddit returns 403 for both non-existent and private subreddits
-            throw new Error(`Cannot access r/${subredditName} - it may be private, quarantined, or doesn't exist. Try a public subreddit like 'programming', 'technology', or 'news'`);
+            throw this.httpError(`Cannot access r/${subredditName} - it may be private, quarantined, or doesn't exist. Try a public subreddit like 'programming', 'technology', or 'news'`, 403);
           }
-          throw new Error('Access forbidden - the requested content may be private or restricted');
+          throw this.httpError('Access forbidden - the requested content may be private or restricted', 403);
         }
         if (response.status === 429) {
-          throw new Error('Rate limited by Reddit - please wait before trying again');
+          throw this.httpError('Rate limited by Reddit - please wait before trying again', 429);
         }
         if (response.status === 503) {
-          throw new Error('Reddit is temporarily unavailable - please try again later');
+          throw this.httpError('Reddit is temporarily unavailable - please try again later', 503);
         }
-        
+
         let errorText = '';
         try {
           errorText = await response.text();
         } catch {
           errorText = 'Unable to read error response';
         }
-        
-        throw new Error(`Reddit API error (${response.status}): ${errorText}`);
+
+        throw this.httpError(`Reddit API error (${response.status}): ${errorText}`, response.status);
       }
 
       // Try to parse JSON

--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -211,7 +211,9 @@ export class RedditAPI {
       // back to the comments page, it's a text post.
       const contentHtml = this.decodeEntities(pick('content') || '');
       const outboundMatch = contentHtml.match(/<a href="([^"]+)">\s*\[link\]/);
-      const outboundUrl = outboundMatch ? outboundMatch[1] : '';
+      // Reddit double-escapes entities inside <content>, so the extracted href
+      // needs a second decode (?a=1&amp;b=2 -> ?a=1&b=2), same as selftext below.
+      const outboundUrl = outboundMatch ? this.decodeEntities(outboundMatch[1]) : '';
       const is_self = !outboundUrl || outboundUrl.includes('/comments/');
       const url = is_self ? `https://www.reddit.com${permalink}` : outboundUrl;
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { RedditAPI } from '../services/reddit-api.js';
+import { RedditAPI, RSS_UNKNOWN_SCORE } from '../services/reddit-api.js';
 import { ContentProcessor } from '../services/content-processor.js';
 import { RedditListing, RedditPost } from '../types/reddit.types.js';
 
@@ -52,6 +52,28 @@ export const redditExplainSchema = z.object({
 });
 
 /**
+ * Shape RSS-sourced posts for consumption by an LLM.
+ *
+ * Reddit's public Atom feed (used as the credential-free fallback) does not
+ * include engagement metrics — score, num_comments and upvote_ratio are absent.
+ * The API client marks those fields with RSS_UNKNOWN_SCORE; here they are
+ * normalized to null and an explanatory note is attached so the model treats
+ * them as unavailable rather than inferring popularity from placeholder values.
+ */
+function shapeRssPosts(posts: any[]): { posts: any[]; note: string } {
+  const cleaned = posts.map(p => ({
+    ...p,
+    score: p.score === RSS_UNKNOWN_SCORE ? null : p.score,
+    num_comments: p.num_comments === RSS_UNKNOWN_SCORE ? null : p.num_comments,
+    upvote_ratio: p.upvote_ratio ?? null,
+  }));
+  return {
+    posts: cleaned,
+    note: 'Served from Reddit\'s public RSS feed (credential-free fallback used because the JSON API was unavailable). score, num_comments, and upvote_ratio are not provided by RSS and are null — do not infer or estimate popularity from them.',
+  };
+}
+
+/**
  * Tool implementations
  */
 export class RedditTools {
@@ -94,10 +116,21 @@ export class RedditTools {
       link_flair_text: child.data.link_flair_text,
     }));
 
+    const dataSource = listing.data._source ?? 'api';
+
     let result: any = {
       posts,
-      total_posts: posts.length
+      total_posts: posts.length,
+      data_source: dataSource,
     };
+
+    // When data came from the RSS fallback, engagement metrics are unavailable.
+    // Shape them so the LLM doesn't fabricate popularity numbers.
+    if (dataSource === 'rss') {
+      const shaped = shapeRssPosts(posts);
+      result.posts = shaped.posts;
+      result.note = shaped.note;
+    }
 
     // Optionally fetch subreddit info
     if (params.include_subreddit_info) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,7 +14,7 @@ export const browseSubredditSchema = z.object({
   time: z.enum(['hour', 'day', 'week', 'month', 'year', 'all']).optional(),
   limit: z.number().min(1).max(100).optional().default(25).describe('Default 25, range (1-100). Change ONLY IF user specifies.'),
   include_nsfw: z.boolean().optional().default(false),
-  include_subreddit_info: z.boolean().optional().default(false).describe('Include subreddit metadata like subscriber count and description'),
+  include_subreddit_info: z.boolean().optional().default(false).describe('Include subreddit metadata like subscriber count and description. Requires Reddit credentials; silently omitted when browsing anonymously via the RSS fallback'),
 });
 
 export const searchRedditSchema = z.object({

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -59,6 +59,11 @@ export const redditExplainSchema = z.object({
  * The API client marks those fields with RSS_UNKNOWN_SCORE; here they are
  * normalized to null and an explanatory note is attached so the model treats
  * them as unavailable rather than inferring popularity from placeholder values.
+ *
+ * The feed also carries no per-post over_18 flag, so the include_nsfw filter
+ * cannot apply to RSS results — nsfw is set to null and the note discloses it.
+ * (Reddit's logged-out feed refuses NSFW subreddits outright with an error,
+ * but individual posts inside SFW subreddits come with no flag to check.)
  */
 function shapeRssPosts(posts: any[]): { posts: any[]; note: string } {
   const cleaned = posts.map(p => ({
@@ -66,10 +71,11 @@ function shapeRssPosts(posts: any[]): { posts: any[]; note: string } {
     score: p.score === RSS_UNKNOWN_SCORE ? null : p.score,
     num_comments: p.num_comments === RSS_UNKNOWN_SCORE ? null : p.num_comments,
     upvote_ratio: p.upvote_ratio ?? null,
+    nsfw: p.nsfw ?? null,
   }));
   return {
     posts: cleaned,
-    note: 'Served from Reddit\'s public RSS feed (credential-free fallback used because the JSON API was unavailable). score, num_comments, and upvote_ratio are not provided by RSS and are null — do not infer or estimate popularity from them.',
+    note: 'Served from Reddit\'s public RSS feed (credential-free fallback used because the JSON API was unavailable). score, num_comments, and upvote_ratio are not provided by RSS and are null — do not infer or estimate popularity from them. NSFW flags are also not provided (nsfw is null), so the include_nsfw filter does not apply to these posts; Reddit\'s logged-out feed blocks NSFW subreddits entirely, but posts within other subreddits are unfiltered.',
   };
 }
 
@@ -89,7 +95,8 @@ export class RedditTools {
       }
     );
 
-    // Filter NSFW content unless requested
+    // Filter NSFW content unless requested. RSS-sourced posts carry no
+    // over_18 flag and pass through — disclosed via the note in shapeRssPosts.
     if (!params.include_nsfw) {
       listing.data.children = listing.data.children.filter(
         child => !child.data.over_18

--- a/src/types/reddit.types.ts
+++ b/src/types/reddit.types.ts
@@ -91,6 +91,10 @@ export interface RedditListing<T> {
     }>;
     dist?: number;
     modhash?: string;
+    // Origin of the data. 'rss' means it was synthesized from Reddit's
+    // public Atom feed (credential-free fallback) and lacks engagement
+    // metrics like score/num_comments/upvote_ratio.
+    _source?: 'api' | 'rss';
   };
 }
 

--- a/tests/test-unit.sh
+++ b/tests/test-unit.sh
@@ -1161,6 +1161,53 @@ RSS_HARDENING_RESULT=$(node --input-type=module -e '
 ' 2>/dev/null)
 assert "RSS hardening: bestof link target kept, body-anchor hijack blocked, 429 retry, JSON-skip memo" "echo \"\$RSS_HARDENING_RESULT\" | grep -q '^pass$'"
 
+# --------------------------------------------------------------------------
+# 2u. Auth Privacy: env creds never persisted, custom UA honored (auth.ts) — NEW
+# --------------------------------------------------------------------------
+log_subsection "2u. Auth Privacy — NEW"
+
+AUTH_PRIVACY_RESULT=$(HOME="$(mktemp -d)" REDDIT_CLIENT_ID="testid" REDDIT_CLIENT_SECRET="testsecret" REDDIT_USER_AGENT="CustomUA/1.0" node --input-type=module -e '
+  import { AuthManager } from "./dist/core/auth.js";
+  import { existsSync } from "node:fs";
+  import { readFile } from "node:fs/promises";
+  import { join } from "node:path";
+  import { homedir } from "node:os";
+
+  globalThis.fetch = async () => new Response(JSON.stringify({ access_token: "tok123456789abcdef-mock", token_type: "bearer", expires_in: 3600, scope: "*" }), { status: 200, headers: { "content-type": "application/json" } });
+
+  const authFile = join(homedir(), ".reddit-mcp-buddy", "auth.json");
+
+  // Env-supplied credentials: token refresh must NOT write auth.json
+  // (README privacy contract: env vars are never persisted by this server)
+  const am = new AuthManager();
+  await am.load();
+  await am.refreshAccessToken();
+  const t1 = !existsSync(authFile);
+  const t2 = am.isAuthenticated() === true;
+
+  // REDDIT_USER_AGENT must reach the actual request headers
+  const h = await am.getHeaders();
+  const t3 = h["User-Agent"] === "CustomUA/1.0";
+
+  // --auth-style setup (config set directly, no load()) must STILL persist,
+  // and never with the password
+  const am2 = new AuthManager();
+  am2["config"] = { clientId: "a", clientSecret: "b", username: "u", password: "p", userAgent: "X/1" };
+  await am2.refreshAccessToken();
+  const t4 = existsSync(authFile);
+  const saved = t4 ? JSON.parse(await readFile(authFile, "utf8")) : {};
+  const t5 = t4 && !("password" in saved);
+
+  // Anonymous (no creds): default UA
+  const am3 = new AuthManager();
+  const h3 = await am3.getHeaders();
+  const t6 = h3["User-Agent"] === "RedditBuddy/1.0 (by /u/karanb192)";
+
+  const all = t1 && t2 && t3 && t4 && t5 && t6;
+  console.log(all ? "pass" : "fail:" + JSON.stringify({t1,t2,t3,t4,t5,t6}));
+' 2>/dev/null)
+assert "Auth privacy: env creds never hit disk, --auth persists sans password, custom UA honored" "echo \"\$AUTH_PRIVACY_RESULT\" | grep -q '^pass$'"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # RESULTS

--- a/tests/test-unit.sh
+++ b/tests/test-unit.sh
@@ -1014,6 +1014,53 @@ NOCACHE_TEST=$(node --input-type=module -e "
 " 2>/dev/null)
 assert "REDDIT_BUDDY_NO_CACHE: true/1/yes/on/TRUE/trimmed/false/0/empty/undefined" "[ '$NOCACHE_TEST' = 'pass' ]"
 
+# --------------------------------------------------------------------------
+# 2s. RSS Atom Parser + Anonymous Fallback Shaping (reddit-api.ts, tools/index.ts) — NEW
+# --------------------------------------------------------------------------
+log_subsection "2s. RSS Atom Parser + Fallback Shaping — NEW"
+
+RSS_PARSER_RESULT=$(node --input-type=module -e '
+  import { AuthManager } from "./dist/core/auth.js";
+  import { RateLimiter } from "./dist/core/rate-limiter.js";
+  import { CacheManager } from "./dist/core/cache.js";
+  import { RedditAPI } from "./dist/services/reddit-api.js";
+  import { RedditTools } from "./dist/tools/index.js";
+
+  const api = new RedditAPI({
+    authManager: new AuthManager(),
+    rateLimiter: new RateLimiter({ limit: 10, window: 60000, name: "test" }),
+    cacheManager: new CacheManager(),
+  });
+
+  // Synthetic Reddit Atom feed. Reddit double-escapes entities inside
+  // <content type="html">: a literal & in a link URL appears in raw XML as
+  // &amp;amp; and an apostrophe as &amp;#39;.
+  const xml = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom"><entry><author><name>/u/linkposter</name></author><category term="technology" label="r/technology"/><id>t3_aaa111</id><link href="https://www.reddit.com/r/technology/comments/aaa111/multi_param_link/" /><published>2026-07-10T12:00:00+00:00</published><title>Multi param link post</title><content type="html">&lt;table&gt;&lt;tr&gt;&lt;td&gt; &lt;span&gt;&lt;a href="https://www.youtube.com/watch?v=abc123&amp;amp;t=30s&amp;amp;feature=share"&gt; [link]&lt;/a&gt;&lt;/span&gt; &lt;span&gt;&lt;a href="https://www.reddit.com/r/technology/comments/aaa111/multi_param_link/"&gt;[comments]&lt;/a&gt;&lt;/span&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</content></entry><entry><author><name>/u/selfposter</name></author><category term="technology" label="r/technology"/><id>t3_bbb222</id><link href="https://www.reddit.com/r/technology/comments/bbb222/self_post/" /><published>2026-07-10T13:00:00+00:00</published><title>Self post with entities</title><content type="html">&lt;div class="md"&gt;&lt;p&gt;Tom &amp;amp; Jerry&amp;#39;s guide&lt;/p&gt;&lt;/div&gt; &lt;span&gt;&lt;a href="https://www.reddit.com/r/technology/comments/bbb222/self_post/"&gt; [link]&lt;/a&gt;&lt;/span&gt;</content></entry></feed>`;
+
+  const listing = api["parseAtomFeed"](xml, "technology");
+  const [link, self] = listing.data.children.map(c => c.data);
+
+  // Outbound link URLs must be decoded TWICE (2+ query params survive intact)
+  const t1 = link.url === "https://www.youtube.com/watch?v=abc123&t=30s&feature=share";
+  const t2 = link.is_self === false && link.id === "aaa111";
+  const t3 = self.is_self === true;
+  const t4 = self.selftext === "Tom & Jerry\u0027s guide";
+  // RSS has no over_18 flag — parser must not invent one
+  const t5 = link.over_18 === undefined;
+  const t6 = listing.data._source === "rss";
+
+  // Tools-layer shaping: metrics and nsfw surface as explicit null + note
+  const tools = new RedditTools({ browseSubreddit: async () => listing });
+  const res = await tools.browseSubreddit({ subreddit: "technology", sort: "hot", limit: 25, include_nsfw: false });
+  const t7 = res.data_source === "rss";
+  const t8 = res.posts[0].nsfw === null && res.posts[0].score === null && res.posts[0].num_comments === null;
+  const t9 = /NSFW flags are also not provided/.test(res.note) && /do not infer or estimate popularity/.test(res.note);
+
+  const all = t1 && t2 && t3 && t4 && t5 && t6 && t7 && t8 && t9;
+  console.log(all ? "pass" : "fail:" + JSON.stringify({t1,t2,t3,t4,t5,t6,t7,t8,t9}));
+' 2>/dev/null)
+assert "RSS fallback: double-decoded URLs, selftext, null metrics/nsfw + note" "echo \"\$RSS_PARSER_RESULT\" | grep -q '^pass$'"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # RESULTS

--- a/tests/test-unit.sh
+++ b/tests/test-unit.sh
@@ -1061,6 +1061,106 @@ RSS_PARSER_RESULT=$(node --input-type=module -e '
 ' 2>/dev/null)
 assert "RSS fallback: double-decoded URLs, selftext, null metrics/nsfw + note" "echo \"\$RSS_PARSER_RESULT\" | grep -q '^pass$'"
 
+# --------------------------------------------------------------------------
+# 2t. RSS Fallback Hardening: is_self heuristic, 429 retry, JSON-skip memo — NEW
+# --------------------------------------------------------------------------
+log_subsection "2t. RSS Fallback Hardening — NEW"
+
+RSS_HARDENING_RESULT=$(node --input-type=module -e '
+  import { AuthManager } from "./dist/core/auth.js";
+  import { RateLimiter } from "./dist/core/rate-limiter.js";
+  import { CacheManager } from "./dist/core/cache.js";
+  import { RedditAPI } from "./dist/services/reddit-api.js";
+
+  const mk = () => new RedditAPI({
+    authManager: new AuthManager(),
+    rateLimiter: new RateLimiter({ limit: 100, window: 60000, name: "test" }),
+    cacheManager: new CacheManager(),
+  });
+  const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const entry = (id, permalink, content) => `<entry><author><name>/u/x</name></author><id>t3_${id}</id><link href="https://www.reddit.com${permalink}" /><published>2026-07-10T12:00:00+00:00</published><title>t</title><content type="html">${esc(content)}</content></entry>`;
+  const feed = (...es) => `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom">${es.join("")}</feed>`;
+
+  // t1: link post targeting ANOTHER Reddit thread keeps its outbound URL
+  // (r/bestof pattern — must not be misclassified as a self post)
+  const own1 = "/r/bestof/comments/aaa/xxx/";
+  const target = "https://www.reddit.com/r/Awww/comments/bbb/yyy/zzz/";
+  const p1 = mk()["parseAtomFeed"](feed(entry("aaa", own1, `<span><a href="${target}"> [link]</a></span> <span><a href="https://www.reddit.com${own1}">[comments]</a></span>`)), "bestof").data.children[0].data;
+  const t1 = p1.is_self === false && p1.url === target;
+
+  // t2: a "[link]" anchor crafted inside a self-post body cannot hijack url
+  // (Reddit footer anchor comes last and must win)
+  const own2 = "/r/test/comments/ccc/zzz/";
+  const p2 = mk()["parseAtomFeed"](feed(entry("ccc", own2, `<div class="md"><p>body text <a href="https://evil.example/">[link]</a></p></div> <span><a href="https://www.reddit.com${own2}"> [link]</a></span>`)), "test").data.children[0].data;
+  const t2 = p2.is_self === true && p2.url === `https://www.reddit.com${own2}` && p2.selftext.includes("body text");
+
+  const atomOk = () => new Response(feed(entry("ok1", "/r/programming/comments/ok1/t/", `<span><a href="https://example.com/a"> [link]</a></span>`)), { status: 200, headers: { "content-type": "application/atom+xml" } });
+  const blocked = () => new Response("blocked", { status: 403, headers: { "content-type": "text/html" } });
+
+  // t3: transient RSS 429 is retried (honoring Retry-After) and succeeds
+  let rss3 = 0;
+  globalThis.fetch = async (url) => String(url).includes(".rss")
+    ? (++rss3 === 1 ? new Response("", { status: 429, headers: { "retry-after": "0" } }) : atomOk())
+    : blocked();
+  const l3 = await mk().browseSubreddit("programming", "hot", { limit: 5 });
+  const t3 = l3.data._source === "rss" && rss3 === 2;
+
+  // t4: persistent 429 stops after initial + 2 retries and fails cleanly
+  let rss4 = 0;
+  globalThis.fetch = async (url) => String(url).includes(".rss")
+    ? (rss4++, new Response("", { status: 429, headers: { "retry-after": "0" } }))
+    : blocked();
+  let err4 = "";
+  try { await mk().browseSubreddit("programming", "hot", { limit: 5 }); } catch (e) { err4 = e.message; }
+  const t4 = rss4 === 3 && err4.includes("429");
+
+  // t5: once the .json block is proven (RSS succeeded), later browses skip
+  // the doomed .json probe entirely for the session
+  const log5 = [];
+  globalThis.fetch = async (url) => { log5.push(String(url)); return String(url).includes(".rss") ? atomOk() : blocked(); };
+  const api5 = mk();
+  await api5.browseSubreddit("programming", "hot", { limit: 5 });
+  const jsonProbes = log5.filter(u => u.includes(".json")).length;
+  log5.length = 0;
+  await api5.browseSubreddit("askreddit", "new", { limit: 5 });
+  const t5 = jsonProbes === 1 && log5.length === 1 && log5[0].includes(".rss");
+
+  // t6: memo NOT set when RSS also failed (network down is not a proven
+  // policy block) — next browse re-probes .json
+  const log6 = [];
+  let up6 = false;
+  globalThis.fetch = async (url) => { log6.push(String(url)); return String(url).includes(".rss") ? (up6 ? atomOk() : new Response("", { status: 500 })) : blocked(); };
+  const api6 = mk();
+  let threw6 = false;
+  try { await api6.browseSubreddit("programming", "hot", { limit: 5 }); } catch { threw6 = true; }
+  up6 = true; log6.length = 0;
+  await api6.browseSubreddit("askreddit", "new", { limit: 5 });
+  const t6 = threw6 && log6.some(u => u.includes(".json"));
+
+  // t7: memoized-path errors carry subreddit context (404 -> not found)
+  const api7 = mk();
+  globalThis.fetch = async (url) => String(url).includes(".rss") ? atomOk() : blocked();
+  await api7.browseSubreddit("programming", "hot", { limit: 5 }); // latch memo (403 + RSS ok)
+  globalThis.fetch = async () => new Response("", { status: 404 });
+  let err7 = "";
+  try { await api7.browseSubreddit("nosuchsub12345", "hot", { limit: 5 }); } catch (e) { err7 = e.message; }
+  const t7 = err7.includes("r/nosuchsub12345") && /does not exist/i.test(err7);
+
+  // t8: transient JSON 500 does NOT latch the memo — only the 403 block
+  // signature does; next browse re-probes .json
+  const log8 = [];
+  globalThis.fetch = async (url) => { log8.push(String(url)); return String(url).includes(".rss") ? atomOk() : new Response("", { status: 500 }); };
+  const api8 = mk();
+  await api8.browseSubreddit("programming", "hot", { limit: 5 });
+  log8.length = 0;
+  await api8.browseSubreddit("askreddit", "new", { limit: 5 });
+  const t8 = log8.some(u => u.includes(".json"));
+
+  const all = t1 && t2 && t3 && t4 && t5 && t6 && t7 && t8;
+  console.log(all ? "pass" : "fail:" + JSON.stringify({t1,t2,t3,t4,t5,t6,t7,t8}));
+' 2>/dev/null)
+assert "RSS hardening: bestof link target kept, body-anchor hijack blocked, 429 retry, JSON-skip memo" "echo \"\$RSS_HARDENING_RESULT\" | grep -q '^pass$'"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # RESULTS


### PR DESCRIPTION
## Summary

Restores a working **anonymous** `browse_subreddit` by falling back to Reddit's public Atom (RSS) feed when the unauthenticated JSON API is blocked. Partially addresses the "anonymous mode no longer works" reports (#58, #59) — browse only. The broader rate-limit/docs rewrite (#34, #39) is tracked separately; this PR updates only the docs its behavior change directly invalidates (README anonymous-mode claims, tool descriptions, registry description).

This is a focused re-do of #60 — **only the RSS fallback**, with the unrelated `.mcpb` build tooling dropped (can land separately). Original work by @TusharKanjariya (credited as co-author).

## Why

Reddit network-blocks the unauthenticated JSON API from many IPs (datacenter/VPN/flagged), returning `403` + the HTML "whoa there, pardner" block page regardless of User-Agent. The public `.rss` endpoint still serves without credentials.

Verified live on this machine:

| Request | Result |
| --- | --- |
| `GET /r/programming/hot.json` (anon) | **403** `text/html`, 190 KB block page |
| `GET /r/programming/hot/.rss` (anon) | **200** `application/atom+xml`, valid feed |

## How it works

- `browseSubreddit` tries the JSON API first. If it throws **and** we're anonymous, it falls back to `browseSubredditViaRSS`.
- **Blocked-probe memo**: when the anonymous `.json` attempt fails with a **403** and RSS then succeeds (the signature of Reddit's IP-level block — a private/nonexistent subreddit can't produce that pair, its RSS fails too), the doomed `.json` probe is skipped for the next 15 minutes (`anonJsonBlockedUntil`) instead of being repeated on every cache miss. Transient `.json` errors (500/timeout) do **not** latch. HTTP-status errors now carry a `.status` property (`httpError()`) so this check doesn't parse message text.
- Authenticated requests go to `oauth.reddit.com` and **never** hit this path — real failures there are not masked.
- **RSS retry**: `getRSS` retries 429/503 up to 2× like the JSON path, honoring `Retry-After`, then Reddit's `x-ratelimit-reset` (+1s cushion), then exponential backoff — each wait capped at 30s. Reddit's logged-out feed throttles per-IP in ~25–60s windows, so without this most consecutive anonymous browses failed hard (measured live: 13/18 browses 429'd pre-retry).
- A new Atom parser maps entries into the existing `RedditListing<RedditPost>` shape.
- **Link/self detection**: the outbound URL is the **last** `[link]` anchor in the entry content (Reddit's footer follows the body, so an anchor crafted inside a self-post's own text can't hijack the post URL), and a post is a self post only when that target's path equals the entry's **own permalink** path (host/query/trailing-slash insensitive) — not when the target merely contains `/comments/`, so link posts targeting other Reddit threads (r/bestof, crossposts) keep their real target URL.
- RSS has no engagement metrics, so `score` / `num_comments` / `upvote_ratio` are returned as `null` with `data_source: "rss"` and a note telling the model not to infer popularity from them.
- RSS also has no per-post NSFW flag, so `nsfw` is `null` and the note discloses that the `include_nsfw` filter does not apply to RSS results (Reddit's logged-out feed refuses NSFW subreddits outright, but individual posts inside SFW subreddits carry no flag to check).
- RSS-path `404`/`403`/`429` failures name the subreddit and likely cause (e.g. `Not found - r/X does not exist...`) instead of a bare `RSS feed request failed (NNN)`, since with the memo active these errors reach the user directly.

## Verification

- ✅ `npm run build` + `npm run typecheck` pass
- ✅ Parser tested against the **real** current `r/programming` Atom feed → 5/5 posts with correct ids, authors, titles, dates; independently cross-checked on 145 entries across 7 live feeds (r/programming, r/AskReddit, r/worldnews, r/pics, r/france) — every parsed field matched a re-extraction of the raw XML
- ✅ End-to-end through the built code in anonymous mode: JSON fails → RSS fallback → real posts returned with `data_source: "rss"`
- ✅ Adversarial multi-agent review of the diff; all confirmed findings fixed (`84fc929`, `847e92a`):
  - link-post URLs with 2+ query params were mangled (double-escaped entities; now decoded twice like the selftext path)
  - the default NSFW filter silently no-oped on RSS posts — surfaced honestly as `nsfw: null` + disclosure
  - link posts targeting Reddit comment threads (r/bestof pattern) lost their target URL to the `/comments/` substring heuristic — now permalink-comparison based
  - a `[link]` anchor crafted inside a self-post body could hijack the post's `url` — now the footer (last) anchor wins
  - RSS 429s failed hard with no retry exactly when the fallback was needed — now retried honoring rate-limit headers
  - every anonymous cache miss re-probed the known-blocked `.json` endpoint — now memoized for 15 min on the 403+RSS-success signature
- ✅ Deterministic tests **committed to the CI suite** (`tests/test-unit.sh` §2s + §2t + §2u, offline fixtures, 42/42): double-decoded multi-param URLs, double-escaped selftext, id/self-post detection, null-metric shaping contract, bestof-style target preservation, body-anchor hijack rejection, 429 retry-then-success, 3-attempts-then-fail, JSON-skip memo, no-latch-on-transient-500, no-latch-when-RSS-fails, subreddit-aware memoized 404 errors
- ✅ Live stdio MCP session against the built server with an empty `HOME` (true clean machine): boots `Mode: Anonymous` → JSON 403 → RSS fallback → `data_source: "rss"` with null metrics + note; same session with credentials boots `App-Only` → `data_source: "api"` with real scores — top post matched across both sources

## Known limitations (honest caveats)

- **Only `browse_subreddit`** gets the fallback. `search_reddit`, `get_post_details`, and `user_analysis` still require credentials anonymously.
- **No engagement metrics** over RSS (nulled by design).
- **No NSFW filtering** over RSS — the feed carries no per-post `over_18` flag, so `include_nsfw: false` cannot be enforced on RSS results. `nsfw` is `null` and the response note says so explicitly. Mitigation: Reddit's logged-out feed blocks NSFW subreddits entirely at the source.
- **RSS is per-IP rate-limited** (~1 request per ~25–60s window once tripped). The retry absorbs transient 429s, but sustained bursts can still exhaust the 2 retries and fail; worst-case latency for a throttled browse is ~60–90s of header-directed waiting.
- The memoized RSS path does not go through the JSON path's in-flight request dedup, so two concurrent identical browses can fetch the feed twice (pre-existing on the fallback path).

## Also in this PR: README + auth accuracy pass

Every README claim, link, and anchor was verified against the code and live endpoints (`c193491`), and two privacy/config claims the code did not keep were fixed **in code** rather than softened in docs (`4308993`):

- `AuthManager` no longer persists env-supplied credentials: token refresh writes `~/.reddit-mcp-buddy/auth.json` only for `--auth` CLI setups (never the password); env-var setups keep tokens in memory, matching the README's "environment variables are never persisted" promise.
- `REDDIT_USER_AGENT` now reaches actual request headers (`getHeaders()`), not just the OAuth token exchange.
- README fixes: `$(npm bin -g)` (removed in npm 9) → `$(npm prefix -g)/bin`; Docker Hub image that doesn't exist → local `docker build` flow; two broken TOC anchors; three dead external links (MCP spec, awesome-mcp-servers, registry UUID endpoint) and a registry `jq` example that printed nulls; the dead-code "Adaptive TTLs" claim → real per-content TTLs; "Only `browse_subreddit` works" → also offline `reddit_explain`; misleading "MCP Registry" badge removed; stale "(September 2025) preview" note dropped; the file's single em dash removed.
- `tests/test-unit.sh` §2u: env creds never hit disk, custom UA honored, `--auth` persistence (sans password) intact — suite 42/42.

## Scope

RSS core:
- `src/services/reddit-api.ts` — fallback + blocked-probe memo + Atom parser + `getRSS` with retry + `httpError`/`getRateLimitResetDelay` helpers
- `src/tools/index.ts` — `data_source` + null-shaping note
- `src/types/reddit.types.ts` — `_source` on the listing

Auth/docs accuracy pass:
- `src/core/auth.ts` — env credentials never persisted; `REDDIT_USER_AGENT` honored

Docs/metadata (rate-limit tier rewrite deliberately excluded → #34/#39):
- `README.md` — anonymous mode = browse-only via RSS, tool note, troubleshooting entry, plus the broken-command/link/claim corrections above
- `src/mcp-server.ts` — `browse_subreddit` description now tells the model about `data_source` / null metrics instead of promising scores unconditionally
- `server.json` — registry description scopes "no API keys" to browsing
- `tests/test-unit.sh` — offline parser + shaping unit test (§2s), fallback-hardening tests (§2t), auth-privacy tests (§2u)

Supersedes #60.

Generated with Claude Code
