### PR TITLE
Add beacon.json for Beacon discovery listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,3 +551,8 @@ MIT - Use it however you want!
 ---
 
 Made with ❤️ for the MCP community. No venture capital, no tracking, just a good MCP server.
+## Discovery
+
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/karanb192%2Freddit-mcp-buddy/badge.svg)](https://portal-five-phi-54.vercel.app/?q=karanb192%2Freddit-mcp-buddy)
+
+Listed on [Beacon](https://portal-five-phi-54.vercel.app) — searchable index of open-source MCP servers.

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,26 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "karanb192/reddit-mcp-buddy",
+  "name": "Reddit Mcp Buddy",
+  "description": "Open-source AI agent \u2014 ai-assistant, claude, mcp, mcp-server.",
+  "capabilities": [
+    "ai-assistant",
+    "claude",
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "reddit",
+    "reddit-api",
+    "clean",
+    "llm-optimized",
+    "server"
+  ],
+  "interfaces": [
+    {
+      "type": "mcp",
+      "endpoint": "https://github.com/karanb192/reddit-mcp-buddy"
+    }
+  ],
+  "source": "https://github.com/karanb192/reddit-mcp-buddy",
+  "homepage": "https://github.com/karanb192/reddit-mcp-buddy"
+}


### PR DESCRIPTION
Adds Beacon Agent Manifest v0.1 for capability search on https://portal-five-phi-54.vercel.app — opt-in metadata, no runtime changes. Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest

Made with [Cursor](https://cursor.com)