### PR TITLE
fix: harden HTTP mode, validate Reddit identifiers, stop cache mutation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  version-parity:
+    name: Version Parity
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # A release requires the same version in package.json, server.json
+      # (twice), manifest.json and SERVER_VERSION. Drift here ships a bundle
+      # that misreports itself, so fail the build instead of finding out after
+      # publishing.
+      - name: Check version fields agree
+        run: |
+          PKG=$(jq -r .version package.json)
+          SRV=$(jq -r .version server.json)
+          SRV_PKG=$(jq -r '.packages[0].version' server.json)
+          MAN=$(jq -r .version manifest.json)
+          CODE=$(grep -oE "SERVER_VERSION = '[^']+'" src/mcp-server.ts | cut -d"'" -f2)
+          BUNDLE=$(jq -r .version bundle.config.json)
+          echo "package.json=$PKG server.json=$SRV server.json:packages[0]=$SRV_PKG manifest.json=$MAN SERVER_VERSION=$CODE bundle.config.json=$BUNDLE"
+          FAILED=0
+          for pair in "server.json:$SRV" "server.json:packages[0]:$SRV_PKG" "manifest.json:$MAN" "src/mcp-server.ts SERVER_VERSION:$CODE" "bundle.config.json:$BUNDLE"; do
+            NAME=${pair%:*}; VAL=${pair##*:}
+            if [ "$VAL" != "$PKG" ]; then
+              echo "::error::$NAME is $VAL but package.json is $PKG"
+              FAILED=1
+            fi
+          done
+          [ "$FAILED" = "0" ] || exit 1
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -50,6 +81,8 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # No continue-on-error: checks that genuinely need credentials skip
+      # themselves when none are configured, so a red run means a real
+      # regression rather than an environment limitation.
       - name: Run integration tests
         run: bash tests/test-integration.sh
-        continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ EXPOSE 3000
 
 # Set environment variables
 ENV REDDIT_BUDDY_HTTP=true
+# The server binds loopback by default. Inside a container that would make the
+# published port unreachable, so bind all interfaces here — the container
+# boundary (and whatever you publish with -p) is the real access control.
+ENV REDDIT_BUDDY_HOST=0.0.0.0
 ENV NODE_ENV=production
 
 # Use dumb-init to handle signals properly

--- a/README.md
+++ b/README.md
@@ -468,7 +468,12 @@ $(npm prefix -g)/bin/reddit-mcp-buddy
 |----------|-------------|---------|
 | `REDDIT_BUDDY_HTTP` | Run as HTTP server instead of stdio | `false` |
 | `REDDIT_BUDDY_PORT` | HTTP server port (when HTTP=true) | `3000` |
+| `REDDIT_BUDDY_HOST` | Interface the HTTP server binds to | `127.0.0.1` |
+| `REDDIT_BUDDY_ALLOWED_ORIGINS` | Comma-separated browser origins allowed to call the HTTP endpoint | none |
+| `REDDIT_BUDDY_ALLOWED_HOSTS` | Comma-separated `host:port` values accepted in the Host header (DNS-rebinding protection) | loopback values when bound to localhost |
 | `REDDIT_BUDDY_NO_CACHE` | Disable caching (always fetch fresh) | `false` |
+
+> **HTTP mode has no authentication.** It binds to localhost so only your machine can reach it, and rejects Host headers outside the loopback set. Setting `REDDIT_BUDDY_HOST=0.0.0.0` exposes it to your whole network - only do that on a trusted network (e.g. inside Docker, which sets it deliberately). On a non-loopback bind the Host check is off by default, since clients legitimately arrive with a container IP or service name; set `REDDIT_BUDDY_ALLOWED_HOSTS` to restrict it. Browser requests are rejected unless their origin is listed in `REDDIT_BUDDY_ALLOWED_ORIGINS`; non-browser clients like Postman are unaffected.
 
 ## Technical Details
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,6 @@ You can expect:
 
 ## Known Security Considerations
 
-**HTTP mode has no authentication.** When running with `REDDIT_BUDDY_HTTP=true`, the MCP server accepts requests from any client with no auth. This is intentional for local use — the server is designed to run on `localhost` only. Do not expose it on a public or shared network interface.
+**HTTP mode has no authentication.** When running with `REDDIT_BUDDY_HTTP=true`, the MCP server accepts requests from any client on the interface it binds with no auth. It therefore binds `127.0.0.1` by default, and rejects browser requests whose `Origin` is not listed in `REDDIT_BUDDY_ALLOWED_ORIGINS`. Setting `REDDIT_BUDDY_HOST` to another interface (as the Docker image does) exposes an unauthenticated server to that network - only do so on a network you trust, and never on a public one.
 
 **Reddit credentials** (client ID, secret, password) should be passed via environment variables, not committed to config files.

--- a/bundle.config.json
+++ b/bundle.config.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.12",
+  "version": "1.1.14",
   "displayName": "Reddit MCP Buddy",
   "description": "Browse Reddit without leaving Claude",
   "author": "Karan Bansal",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "reddit-mcp-buddy",
   "display_name": "Reddit MCP Buddy",
-  "version": "1.1.12",
+  "version": "1.1.14",
   "description": "Browse Reddit directly in Claude Desktop. Search posts, analyze users, explore communities - no API keys needed.",
   "long_description": "Reddit MCP Buddy brings the entire Reddit ecosystem to Claude Desktop with zero configuration required.\n\n**Key Features:**\n• Browse any subreddit with sorting options (hot, new, top, rising)\n• Search Reddit content across all communities\n• Analyze user profiles with karma and post history\n• Get full post details including comments\n• Understand Reddit culture and terminology\n\n**Why Choose Reddit MCP Buddy:**\n• **No API Keys Required** - Works instantly in anonymous mode\n• **Smart Caching** - Fast responses with intelligent caching\n• **Rate Limit Optimized** - Up to 100 requests/minute with authentication\n• **Clean Data** - Only real Reddit data, no fake metrics\n• **Cross-Platform** - Works on Windows, macOS, and Linux\n\n**Perfect for:**\n• Market research and trend analysis\n• Community sentiment monitoring\n• Content discovery and curation\n• User behavior analysis\n• Real-time discussion tracking",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.6",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reddit-mcp-buddy",
-      "version": "1.1.6",
+      "version": "1.1.13",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.6"
       },
@@ -21,88 +21,12 @@
         "@types/node": "^20.14.10",
         "@typescript-eslint/eslint-plugin": "^7.16.0",
         "@typescript-eslint/parser": "^7.16.0",
-        "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^8.57.0",
         "tsx": "^4.16.2",
-        "typescript": "^5.5.3",
-        "vitest": "^3.2.4"
+        "typescript": "^5.5.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.4"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -634,6 +558,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -696,124 +632,67 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.0.tgz",
-      "integrity": "sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -852,335 +731,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.1.tgz",
-      "integrity": "sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.1.tgz",
-      "integrity": "sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.1.tgz",
-      "integrity": "sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.1.tgz",
-      "integrity": "sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.1.tgz",
-      "integrity": "sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.1.tgz",
-      "integrity": "sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.1.tgz",
-      "integrity": "sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.1.tgz",
-      "integrity": "sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.1.tgz",
-      "integrity": "sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.1.tgz",
-      "integrity": "sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.1.tgz",
-      "integrity": "sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.1.tgz",
-      "integrity": "sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.1.tgz",
-      "integrity": "sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.1.tgz",
-      "integrity": "sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.1.tgz",
-      "integrity": "sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.1.tgz",
-      "integrity": "sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.1.tgz",
-      "integrity": "sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.1.tgz",
-      "integrity": "sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.1.tgz",
-      "integrity": "sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.1.tgz",
-      "integrity": "sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.1.tgz",
-      "integrity": "sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*"
-      }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.14",
@@ -1392,155 +942,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.2",
-        "ast-v8-to-istanbul": "^0.3.3",
-        "debug": "^4.4.1",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1581,6 +982,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1592,6 +994,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -1636,28 +1077,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz",
-      "integrity": "sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.30",
-        "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1666,23 +1085,40 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1715,16 +1151,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1766,23 +1192,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1798,16 +1207,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1838,15 +1237,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -1920,16 +1320,6 @@
         }
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1986,24 +1376,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2033,17 +1409,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2278,16 +1647,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2328,29 +1687,20 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/expect-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -2381,10 +1731,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -2435,6 +1789,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -2443,6 +1798,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -2481,9 +1852,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2494,7 +1865,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2535,23 +1910,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2778,7 +2136,7 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.1.1",
+      "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
@@ -2790,9 +2148,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2801,48 +2159,49 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -2900,6 +2259,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2917,16 +2285,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2974,82 +2332,14 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
+        "url": "https://github.com/sponsors/panva"
       }
-    },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3075,7 +2365,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3131,60 +2428,8 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/math-intrinsics": {
-      "version": "1.1.1",
+      "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
@@ -3193,7 +2438,7 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.1",
+      "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
@@ -3247,15 +2492,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -3274,40 +2523,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3417,13 +2637,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3475,27 +2688,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3511,30 +2707,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3556,35 +2728,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -3614,18 +2757,20 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3656,43 +2801,40 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
       }
     },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/resolve-from": {
@@ -3743,47 +2885,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.50.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
-      "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.50.1",
-        "@rollup/rollup-android-arm64": "4.50.1",
-        "@rollup/rollup-darwin-arm64": "4.50.1",
-        "@rollup/rollup-darwin-x64": "4.50.1",
-        "@rollup/rollup-freebsd-arm64": "4.50.1",
-        "@rollup/rollup-freebsd-x64": "4.50.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.50.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.50.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.50.1",
-        "@rollup/rollup-linux-arm64-musl": "4.50.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.50.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.50.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.50.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.50.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.50.1",
-        "@rollup/rollup-linux-x64-gnu": "4.50.1",
-        "@rollup/rollup-linux-x64-musl": "4.50.1",
-        "@rollup/rollup-openharmony-arm64": "4.50.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.50.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.50.1",
-        "@rollup/rollup-win32-x64-msvc": "4.50.1",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -3824,26 +2925,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3864,31 +2945,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -3898,6 +2983,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -3929,13 +3018,13 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3947,13 +3036,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3999,26 +3088,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4029,23 +3098,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4055,98 +3107,7 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4172,19 +3133,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4198,140 +3146,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -4415,17 +3235,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -4462,6 +3299,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -4474,221 +3312,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vite": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {
@@ -4706,23 +3329,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/why-is-node-running": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4731,107 +3337,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -4863,12 +3368,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Clean, LLM-optimized Reddit MCP server. Browse posts, search content, analyze users. No fluff, just Reddit data.",
   "main": "dist/index.js",
   "mcpName": "io.github.karanb192/reddit-mcp-buddy",
@@ -50,7 +50,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.24.6"
   },
@@ -58,11 +58,9 @@
     "@types/node": "^20.14.10",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
-    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^8.57.0",
     "tsx": "^4.16.2",
-    "typescript": "^5.5.3",
-    "vitest": "^3.2.4"
+    "typescript": "^5.5.3"
   },
   "files": [
     "dist",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.karanb192/reddit-mcp-buddy",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Reddit browser for AI assistants. Browse posts without API keys; add Reddit credentials to also search, read comments, and analyze users.",
   "author": {
     "name": "Karan Bansal",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "reddit-mcp-buddy",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "transport": {
         "type": "stdio"
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -29,7 +29,7 @@ import {
 
 // Server metadata
 export const SERVER_NAME = 'reddit-mcp-buddy';
-export const SERVER_VERSION = '1.1.13';
+export const SERVER_VERSION = '1.1.14';
 
 // MCP Response validation schemas (per MCP spec)
 const ContentBlockSchema = z.object({
@@ -123,8 +123,20 @@ function createValidatedResponse(text: string, isError: boolean = false): ToolRe
 /**
  * Create MCP server with proper protocol implementation
  */
-export async function createMCPServer() {
-  // Initialize core components
+export interface SharedServices {
+  cacheManager: CacheManager;
+  tools: RedditTools;
+  rateLimit: number;
+  cacheTTL: number;
+}
+
+/**
+ * Build the long-lived services (auth, cache, rate limiter, Reddit client).
+ * These are created ONCE per process and shared by every MCP server instance,
+ * so the stateless HTTP path can mint a fresh Server per request without
+ * throwing away the cache or resetting the rate limiter.
+ */
+export async function createSharedServices(): Promise<SharedServices> {
   const authManager = new AuthManager();
   await authManager.load();
 
@@ -145,30 +157,41 @@ export async function createMCPServer() {
     defaultTTL: disableCache ? 0 : cacheTTL,
     maxSize: disableCache ? 0 : 50 * 1024 * 1024, // 50MB or 0 if disabled
   });
-  
+
   // Create rate limiter
   const rateLimiter = new RateLimiter({
     limit: rateLimit,
     window: 60000, // 1 minute
     name: 'Reddit API',
   });
-  
+
   // Create Reddit API client
   const redditAPI = new RedditAPI({
     authManager,
     rateLimiter,
     cacheManager,
   });
-  
-  // Create tools instance
-  const tools = new RedditTools(redditAPI);
-  
+
+  return { cacheManager, tools: new RedditTools(redditAPI), rateLimit, cacheTTL };
+}
+
+export async function createMCPServer(shared?: SharedServices) {
+  const services = shared ?? await createSharedServices();
+  const { cacheManager, tools, rateLimit, cacheTTL } = services;
+
   // Create MCP server
   const server = new Server(
     {
       name: SERVER_NAME,
       version: SERVER_VERSION,
-      description: `Reddit content browser and analyzer. Access posts, comments, and user data from Reddit.
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+      // Guidance the client shows the model. This must be `instructions` —
+      // a `description` field on serverInfo is dropped by the protocol.
+      instructions: `Reddit content browser and analyzer. Access posts, comments, and user data from Reddit.
 
 KEY CONCEPTS:
 - Subreddits: Communities like "technology", "science". Use without r/ prefix
@@ -186,45 +209,41 @@ COMMON QUERIES:
 - "Analyze a Reddit user" → user_analysis with username
 
 Rate limits: ${rateLimit} requests/minute. Cache TTL: ${cacheTTL / 60000} minutes.`,
-    },
-    {
-      capabilities: {
-        tools: {},
-      },
     }
   );
-  
+
+
   // Generate tool definitions from Zod schemas with proper type conversion
   const toolDefinitions: Tool[] = [
     {
       name: 'browse_subreddit',
       description: 'Fetch posts from a subreddit sorted by your choice (hot/new/top/rising/controversial). Returns a post list with content, metadata, and a data_source field. With Reddit credentials (data_source "api") posts include score, num_comments, and upvote_ratio; without credentials, results come from Reddit\'s public RSS feed (data_source "rss") and those fields plus nsfw are null — see the response note and do not infer popularity from them.',
       inputSchema: zodSchemaToMCPInputSchema(browseSubredditSchema, 'browse_subreddit'),
-      readOnlyHint: true
+      annotations: { readOnlyHint: true }
     },
     {
       name: 'search_reddit',
       description: 'Search for posts across Reddit or specific subreddits. Returns matching posts with content and metadata.',
       inputSchema: zodSchemaToMCPInputSchema(searchRedditSchema, 'search_reddit'),
-      readOnlyHint: true
+      annotations: { readOnlyHint: true }
     },
     {
       name: 'get_post_details',
       description: 'Fetch a Reddit post with its comments. Requires EITHER url OR post_id. IMPORTANT: When using post_id alone, an extra API call is made to fetch the subreddit first (2 calls total). For better efficiency, always provide the subreddit parameter when known (1 call total).',
       inputSchema: zodSchemaToMCPInputSchema(getPostDetailsSchema, 'get_post_details'),
-      readOnlyHint: true
+      annotations: { readOnlyHint: true }
     },
     {
       name: 'user_analysis',
       description: 'Analyze a Reddit user\'s posting history, karma, and activity patterns. Returns posts, comments, and statistics.',
       inputSchema: zodSchemaToMCPInputSchema(userAnalysisSchema, 'user_analysis'),
-      readOnlyHint: true
+      annotations: { readOnlyHint: true }
     },
     {
       name: 'reddit_explain',
       description: 'Get explanations of Reddit terms, slang, and culture. Returns definition, origin, usage, and examples.',
       inputSchema: zodSchemaToMCPInputSchema(redditExplainSchema, 'reddit_explain'),
-      readOnlyHint: true
+      annotations: { readOnlyHint: true }
     }
   ];
   
@@ -324,25 +343,63 @@ export async function startStdioServer() {
  * Start server with streamable HTTP transport for Postman MCP
  */
 export async function startHttpServer(port: number = 3000) {
-  const { server, cacheManager } = await createMCPServer();
-  
-  // Create transport - stateless mode for simpler setup
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // Stateless mode - no session management
-    enableJsonResponse: false // Use SSE for notifications
-  });
-  
-  // Connect MCP server to transport
-  await server.connect(transport);
-  
+  // Long-lived services (cache, rate limiter, Reddit client) are created once;
+  // the MCP Server and transport are created PER REQUEST below.
+  const shared = await createSharedServices();
+  const { cacheManager } = shared;
+
+  // Bind loopback by default. HTTP mode has no authentication, so exposing it
+  // on other interfaces must be an explicit, deliberate choice (e.g. Docker).
+  const host = (process.env.REDDIT_BUDDY_HOST || '127.0.0.1').trim();
+
+  // IPv6 literals need brackets in a Host header or URL (::1 -> [::1]).
+  const hostForUrl = host.includes(':') ? `[${host}]` : host;
+  const isLoopbackBind = host === '127.0.0.1' || host === 'localhost' || host === '::1';
+
+  // Host allow-list for DNS-rebinding protection. Loopback binds get a safe
+  // built-in list. When the operator deliberately binds a routable interface
+  // (e.g. the Docker image sets 0.0.0.0), clients legitimately arrive with a
+  // container IP, service name or published port in the Host header, and
+  // pinning it protects nothing that the bind choice did not already concede -
+  // so honour REDDIT_BUDDY_ALLOWED_HOSTS if given, and otherwise skip the check
+  // rather than rejecting every real client.
+  const configuredHosts = (process.env.REDDIT_BUDDY_ALLOWED_HOSTS || '')
+    .split(',')
+    .map(h => h.trim())
+    .filter(Boolean);
+  const allowedHosts = configuredHosts.length > 0
+    ? configuredHosts
+    : (isLoopbackBind
+      ? [`${hostForUrl}:${port}`, `localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`]
+      : []);
+  const dnsRebindingProtection = allowedHosts.length > 0;
+
+  // Browsers may only reach this server from origins the operator allow-lists.
+  // Non-browser clients (Postman, curl, MCP clients) send no Origin header and
+  // are unaffected.
+  const allowedOrigins = (process.env.REDDIT_BUDDY_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map(o => o.trim())
+    .filter(Boolean);
+
   // Create HTTP server
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-    // Enable CORS
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, MCP-Session-Id');
+    // CORS: echo back only allow-listed origins, never a wildcard. Without
+    // this, any website the user visits could drive their local MCP server.
+    const origin = req.headers.origin;
+    if (origin) {
+      if (!allowedOrigins.includes(origin)) {
+        res.writeHead(403, { 'Content-Type': 'text/plain' });
+        res.end('Origin not allowed\n');
+        return;
+      }
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+    }
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, MCP-Session-Id, MCP-Protocol-Version, Last-Event-ID');
     res.setHeader('Access-Control-Expose-Headers', 'MCP-Session-Id');
-    
+
     // Handle OPTIONS for CORS preflight
     if (req.method === 'OPTIONS') {
       res.writeHead(200);
@@ -360,8 +417,8 @@ export async function startHttpServer(port: number = 3000) {
         protocol: 'MCP',
         transport: 'streamable-http',
         features: {
-          sessions: true,
-          notifications: true,
+          sessions: false,
+          notifications: false,
           resumability: false
         }
       }));
@@ -420,6 +477,23 @@ export async function startHttpServer(port: number = 3000) {
           clearTimeout(dataTimeoutId);
           try {
             const parsedBody = JSON.parse(body);
+            // Fresh Server + transport per request. Sharing one stateless
+            // transport across clients causes cross-client response
+            // misrouting (GHSA-345p-7cg4-v4c7), and a client closing it
+            // would otherwise disable the endpoint for everyone.
+            const { server } = await createMCPServer(shared);
+            const transport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: undefined, // Stateless mode - no session management
+              enableJsonResponse: false, // Use SSE for notifications
+              enableDnsRebindingProtection: dnsRebindingProtection,
+              ...(dnsRebindingProtection && { allowedHosts }),
+              ...(allowedOrigins.length > 0 && { allowedOrigins }),
+            });
+            res.on('close', () => {
+              transport.close().catch(() => {});
+              server.close().catch(() => {});
+            });
+            await server.connect(transport);
             await transport.handleRequest(req, res, parsedBody);
           } catch (error) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -438,8 +512,18 @@ export async function startHttpServer(port: number = 3000) {
           clearTimeout(dataTimeoutId);
         });
       } else {
-        // GET or DELETE requests
-        await transport.handleRequest(req, res);
+        // Stateless mode has no session to resume or terminate, so GET (SSE)
+        // and DELETE are not applicable. Reject them rather than handing them
+        // to a transport that would tear itself down.
+        res.writeHead(405, { 'Content-Type': 'application/json', 'Allow': 'POST, OPTIONS' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32601,
+            message: `Method ${req.method} not supported on /mcp (stateless mode accepts POST only)`
+          },
+          id: null
+        }));
       }
       return;
     }
@@ -498,11 +582,17 @@ export async function startHttpServer(port: number = 3000) {
   });
 
   // Start listening
-  httpServer.listen(port, () => {
+  httpServer.listen(port, host, () => {
     console.error(`✅ Reddit MCP Buddy Server running (Streamable HTTP)`);
-    console.error(`🌐 Base URL: http://localhost:${port}`);
-    console.error(`📡 MCP endpoint: http://localhost:${port}/mcp`);
+    console.error(`🌐 Base URL: http://${hostForUrl}:${port}`);
+    console.error(`📡 MCP endpoint: http://${hostForUrl}:${port}/mcp`);
     console.error(`🔌 Connect with Postman MCP client`);
+    if (!isLoopbackBind) {
+      console.error(`⚠️  Bound to ${host} - this server has NO authentication. Only do this on a trusted network.`);
+      if (!dnsRebindingProtection) {
+        console.error(`   Set REDDIT_BUDDY_ALLOWED_HOSTS (comma-separated host:port) to restrict which Host headers are accepted.`);
+      }
+    }
     console.error('💡 Tip: Run "reddit-mcp-buddy --auth" for 10x more requests\n');
   });
 }

--- a/src/services/content-processor.ts
+++ b/src/services/content-processor.ts
@@ -378,7 +378,7 @@ export class ContentProcessor {
     // Analyze posting patterns
     const subredditActivity = new Map<string, { posts: number; karma: number }>();
     
-    posts.data.children.forEach(child => {
+    posts.data.children.filter(child => child.data).forEach(child => {
       const item = child.data as any;
       const subreddit = item.subreddit || 'unknown';
       
@@ -402,6 +402,7 @@ export class ContentProcessor {
     
     // Process recent posts (already limited by API call)
     const recentPosts = posts.data.children
+      .filter(child => child.data)
       .map(child => {
         const post = child.data as RedditPost;
         return this.processPost(post);
@@ -410,7 +411,9 @@ export class ContentProcessor {
     // Process recent comments if provided
     let recentComments;
     if (options.comments && options.comments.data.children.length > 0) {
-      recentComments = options.comments.data.children.map(child => {
+      // Reddit sends {kind:'t1', data:null} for some removed comments; drop
+      // them rather than dereferencing null (same guard as the no-posts path).
+      recentComments = options.comments.data.children.filter(child => child.data).map(child => {
         const comment = child.data as any; // Reddit API returns additional fields
         return {
           id: comment.id,

--- a/src/services/reddit-api.ts
+++ b/src/services/reddit-api.ts
@@ -107,7 +107,7 @@ export class RedditAPI {
     }
 
     // All subreddits use /r/ prefix
-    const endpoint = `/r/${subreddit}/${sort}.json`;
+    const endpoint = `/r/${encodeURIComponent(subreddit)}/${sort}.json`;
 
     // Make request, with a credential-free RSS fallback.
     // Reddit network-blocks the unauthenticated .json API from many IPs
@@ -174,7 +174,7 @@ export class RedditAPI {
 
     let xml: string;
     try {
-      xml = await this.getRSS(`/r/${subreddit}/${sort}/.rss?${params.toString()}`);
+      xml = await this.getRSS(`/r/${encodeURIComponent(subreddit)}/${sort}/.rss?${params.toString()}`);
     } catch (error) {
       // Once the JSON probe is skipped (anonJsonBlockedUntil), these errors
       // reach the user directly — give them subreddit context instead of a
@@ -397,7 +397,7 @@ export class RedditAPI {
       // Handle short URLs (redd.it) where subreddit is empty - fall through to lookup
       if (!subreddit) {
         const infoData = await this.get<RedditListing<RedditPost>>(
-          `/api/info.json?id=t3_${id}`
+          `/api/info.json?id=t3_${encodeURIComponent(id)}`
         );
         if (!infoData.data.children.length) {
           throw new Error(`Post with ID ${id} not found`);
@@ -410,7 +410,7 @@ export class RedditAPI {
 
       // Fetch post info to get subreddit
       const infoData = await this.get<RedditListing<RedditPost>>(
-        `/api/info.json?id=t3_${id}`
+        `/api/info.json?id=t3_${encodeURIComponent(id)}`
       );
 
       if (!infoData.data.children.length) {
@@ -435,7 +435,7 @@ export class RedditAPI {
     });
 
     const data = await this.get<[RedditListing<RedditPost>, RedditListing<RedditComment>]>(
-      `/r/${subreddit}/comments/${id}.json?${params.toString()}`
+      `/r/${encodeURIComponent(subreddit)}/comments/${encodeURIComponent(id)}.json?${params.toString()}`
     );
 
     this.cache.set(cacheKey, data);
@@ -487,7 +487,7 @@ export class RedditAPI {
     }
 
     const endpoint = subreddit 
-      ? `/r/${subreddit}/search.json`
+      ? `/r/${encodeURIComponent(subreddit)}/search.json`
       : '/search.json';
 
     const data = await this.get<RedditListing<RedditPost>>(
@@ -511,7 +511,7 @@ export class RedditAPI {
     }
 
     const data = await this.get<{ data: RedditUser }>(
-      `/user/${username}/about.json`
+      `/user/${encodeURIComponent(username)}/about.json`
     );
 
     const user = data.data;
@@ -549,7 +549,7 @@ export class RedditAPI {
     });
 
     const data = await this.get<RedditListing<RedditPost | RedditComment>>(
-      `/user/${username}/${type}.json?${params.toString()}`
+      `/user/${encodeURIComponent(username)}/${type}.json?${params.toString()}`
     );
 
     this.cache.set(cacheKey, data);
@@ -569,7 +569,7 @@ export class RedditAPI {
     }
 
     const data = await this.get<{ data: RedditSubreddit }>(
-      `/r/${name}/about.json`
+      `/r/${encodeURIComponent(name)}/about.json`
     );
 
     const subreddit = data.data;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,9 +7,27 @@ import { RedditAPI, RSS_UNKNOWN_SCORE } from '../services/reddit-api.js';
 import { ContentProcessor } from '../services/content-processor.js';
 import { RedditListing, RedditPost } from '../types/reddit.types.js';
 
+// Reddit identifier formats. These are security boundaries, not just
+// ergonomics: every value below is interpolated into a Reddit API path, and an
+// authenticated request carries the user's OAuth bearer token — so an
+// unconstrained string could steer that token to an arbitrary endpoint.
+// Plain names are [A-Za-z0-9_]{2,21}. Two extra legitimate shapes: profile
+// subreddits (u_<username>, and usernames may contain hyphens and run to 20
+// chars) and multireddit paths (a+b+c), both of which Reddit serves under /r/.
+const SUBREDDIT_RE = /^(?:[A-Za-z0-9_]{2,21}(?:\+[A-Za-z0-9_]{2,21})*|u_[A-Za-z0-9_-]{3,20})$/;
+const USERNAME_RE = /^[A-Za-z0-9_-]{3,20}$/;
+// Post IDs are base36; legacy posts have very short ids, modern ones up to 13.
+const POST_ID_RE = /^[A-Za-z0-9]{2,13}$/;
+
+const subredditName = (description: string) =>
+  z.string()
+    .transform(s => s.trim().replace(/^\/?r\//i, ''))
+    .refine(s => SUBREDDIT_RE.test(s), 'Subreddit must be 2-21 characters (letters, numbers, underscore) without the r/ prefix; u_<username> profile subreddits and a+b multireddits are also accepted')
+    .describe(description);
+
 // Tool schemas
 export const browseSubredditSchema = z.object({
-  subreddit: z.string().describe('Subreddit name without r/ prefix. Use specific subreddit (e.g., "technology"), "all" for Reddit-wide posts, or "popular" for trending across default subreddits'),
+  subreddit: subredditName('Subreddit name without r/ prefix. Use specific subreddit (e.g., "technology"), "all" for Reddit-wide posts, or "popular" for trending across default subreddits'),
   sort: z.enum(['hot', 'new', 'top', 'rising', 'controversial']).optional().default('hot'),
   time: z.enum(['hour', 'day', 'week', 'month', 'year', 'all']).optional(),
   limit: z.number().min(1).max(100).optional().default(25).describe('Default 25, range (1-100). Change ONLY IF user specifies.'),
@@ -19,7 +37,7 @@ export const browseSubredditSchema = z.object({
 
 export const searchRedditSchema = z.object({
   query: z.string().describe('Search query'),
-  subreddits: z.array(z.string()).optional().describe('Subreddits to search in (leave empty for all)'),
+  subreddits: z.array(subredditName('Subreddit name without r/ prefix')).max(10).optional().describe('Subreddits to search in, max 10 (leave empty for all)'),
   sort: z.enum(['relevance', 'hot', 'top', 'new', 'comments']).optional().default('relevance'),
   time: z.enum(['hour', 'day', 'week', 'month', 'year', 'all']).optional().default('all'),
   limit: z.number().min(1).max(100).optional().default(25).describe('Default 25, range (1-100). Override ONLY IF user requests.'),
@@ -28,8 +46,12 @@ export const searchRedditSchema = z.object({
 });
 
 export const getPostDetailsSchema = z.object({
-  post_id: z.string().optional().describe('Reddit post ID (e.g., "1abc2d3")'),
-  subreddit: z.string().optional().describe('Subreddit name (optional with post_id, but more efficient if provided)'),
+  post_id: z.string()
+    .transform(s => s.trim().replace(/^t3_/i, ''))
+    .refine(s => POST_ID_RE.test(s), 'Post ID must be 2-13 alphanumeric characters (e.g. "1abc2d3"), with or without the t3_ prefix')
+    .optional()
+    .describe('Reddit post ID (e.g., "1abc2d3")'),
+  subreddit: subredditName('Subreddit name (optional with post_id, but more efficient if provided)').optional(),
   url: z.string().optional().describe('Full Reddit URL (alternative to post_id)'),
   comment_limit: z.number().min(1).max(500).optional().default(20).describe('Default 20, range (1-500). Change ONLY IF user asks.'),
   comment_sort: z.enum(['best', 'top', 'new', 'controversial', 'qa']).optional().default('best'),
@@ -39,7 +61,10 @@ export const getPostDetailsSchema = z.object({
 });
 
 export const userAnalysisSchema = z.object({
-  username: z.string().describe('Reddit username'),
+  username: z.string()
+    .transform(s => s.trim().replace(/^\/?u(?:ser)?\//i, ''))
+    .refine(s => USERNAME_RE.test(s), 'Username must be 3-20 characters (letters, numbers, underscore, hyphen), without the u/ prefix')
+    .describe('Reddit username without u/ prefix'),
   posts_limit: z.number().min(0).max(100).optional().default(10).describe('Default 10, range (0-100). Change ONLY IF user specifies.'),
   comments_limit: z.number().min(0).max(100).optional().default(10).describe('Default 10, range (0-100). Override ONLY IF user asks.'),
   time_range: z.enum(['day', 'week', 'month', 'year', 'all']).optional().default('month').describe('Time range for posts/comments (default: month). Note: When set to values other than "all", posts are sorted by top scores within that period. When set to "all", posts are sorted by newest'),
@@ -97,14 +122,15 @@ export class RedditTools {
 
     // Filter NSFW content unless requested. RSS-sourced posts carry no
     // over_18 flag and pass through — disclosed via the note in shapeRssPosts.
-    if (!params.include_nsfw) {
-      listing.data.children = listing.data.children.filter(
-        child => !child.data.over_18
-      );
-    }
+    // Filter into a NEW array: `listing` is the cached object by reference, so
+    // reassigning its children would shrink the shared cache entry (the cache
+    // key does not include include_nsfw).
+    const children = listing.data.children.filter(
+      child => child.data && (params.include_nsfw || !child.data.over_18)
+    );
 
     // Extract just the essential fields from Reddit's verbose response
-    const posts = listing.data.children.map(child => ({
+    const posts = children.map(child => ({
       id: child.data.id,
       title: child.data.title,
       author: child.data.author,
@@ -227,22 +253,31 @@ export class RedditTools {
       });
     }
 
+    // Client-side filters. These build NEW arrays: `results` is the cached
+    // object by reference and the cache key excludes author/flair, so
+    // reassigning its children would serve the filtered subset to every later
+    // caller of the same query.
+    let children = results.data.children;
+    const unfilteredCount = children.length;
+
     // Filter by author if specified
     if (params.author) {
-      results.data.children = results.data.children.filter(
-        child => child.data.author.toLowerCase() === params.author!.toLowerCase()
+      const author = params.author.replace(/^\/?u\//i, '').toLowerCase();
+      children = children.filter(
+        child => child.data.author?.toLowerCase() === author
       );
     }
 
     // Filter by flair if specified
     if (params.flair) {
-      results.data.children = results.data.children.filter(
-        child => child.data.link_flair_text?.toLowerCase().includes(params.flair!.toLowerCase())
+      const flair = params.flair.toLowerCase();
+      children = children.filter(
+        child => child.data.link_flair_text?.toLowerCase().includes(flair)
       );
     }
 
     // Extract just the essential fields from Reddit's verbose response
-    const posts = results.data.children.map(child => ({
+    const posts = children.map(child => ({
       id: child.data.id,
       title: child.data.title,
       author: child.data.author,
@@ -260,10 +295,19 @@ export class RedditTools {
       link_flair_text: child.data.link_flair_text,
     }));
 
-    return {
+    const result: any = {
       results: posts,
       total_results: posts.length
     };
+
+    // Author/flair are applied locally, AFTER Reddit truncated the response to
+    // `limit`. Say so, otherwise a short result list reads as "few matches
+    // exist" rather than "few matches were in the first page".
+    if ((params.author || params.flair) && posts.length < unfilteredCount) {
+      result.filter_note = `${unfilteredCount} posts matched the query; ${posts.length} remained after applying the ${[params.author && 'author', params.flair && 'flair'].filter(Boolean).join(' and ')} filter locally. Reddit applies the limit before this filter, so more matches may exist beyond the first ${unfilteredCount} results.`;
+    }
+
+    return result;
   }
 
   async getPostDetails(params: z.infer<typeof getPostDetailsSchema>) {
@@ -287,7 +331,11 @@ export class RedditTools {
       depth: params.comment_depth,
     });
 
-    const post = postListing.data.children[0].data;
+    const postChild = postListing.data.children?.[0];
+    if (!postChild?.data) {
+      throw new Error('Reddit returned no post for that id - it may be removed, quarantined, or withheld in your region');
+    }
+    const post = postChild.data;
 
     // Extract essential post fields
     const cleanPost = {
@@ -325,7 +373,9 @@ export class RedditTools {
     const buildCommentTree = (listing: typeof commentsListing): CommentNode[] => {
       const nodes: CommentNode[] = [];
       for (const child of listing.data.children) {
-        if (child.kind !== 't1') continue;
+        // Reddit sends {kind:'t1', data:null} for some removed comments, and
+        // 'more' stubs are not comments at all.
+        if (child.kind !== 't1' || !child.data) continue;
         const c = child.data;
         const node: CommentNode = {
           id: c.id,

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -126,6 +126,52 @@ skip_test() {
   echo -e "  ${YELLOW}⊘${NC} $description (skipped: $reason)"
 }
 
+# Reddit blocks the logged-out JSON API, so every tool except browse_subreddit
+# (which has the RSS fallback) legitimately cannot work without credentials.
+# Those checks SKIP when running anonymously instead of failing, so a red
+# integration run always means a real regression.
+if [ -n "${REDDIT_CLIENT_ID:-}" ] && [ -n "${REDDIT_CLIENT_SECRET:-}" ]; then
+  HAS_CREDS=1
+else
+  HAS_CREDS=0
+fi
+CRED_SKIP_REASON="requires Reddit credentials (Reddit blocks the anonymous JSON API)"
+
+assert_contains_authed() {
+  if [ "$HAS_CREDS" = "1" ]; then
+    assert_contains "$@"
+  else
+    skip_test "$1" "$CRED_SKIP_REASON"
+  fi
+}
+
+assert_authed() {
+  if [ "$HAS_CREDS" = "1" ]; then
+    assert "$@"
+  else
+    skip_test "$1" "$CRED_SKIP_REASON"
+  fi
+}
+
+# Reddit throttles the logged-out RSS feed per IP (roughly one uncached request
+# per 25-60s), and CI runners share heavily-used addresses. A throttled or
+# blocked response is an environment limitation, not a regression, so these
+# checks SKIP on that signal instead of failing the build.
+is_throttled() {
+  echo "$1" | grep -qE '429|[Rr]ate.limit|rate-limited|Both the JSON API and the RSS fallback failed|whoa there'
+}
+
+assert_contains_live() {
+  local description="$1"
+  local haystack="$2"
+  local needle="$3"
+  if is_throttled "$haystack"; then
+    skip_test "$description" "Reddit throttled the request (HTTP 429)"
+  else
+    assert_contains "$description" "$haystack" "$needle"
+  fi
+}
+
 # Rate limit aware wait
 rate_limit_guard() {
   API_CALLS=$((API_CALLS + 1))
@@ -290,10 +336,23 @@ assert "Unknown endpoint returns 404" "[ '$NOT_FOUND_CODE' = '404' ]"
 # --------------------------------------------------------------------------
 log_subsection "3c. CORS Headers"
 
+# The server never sends a wildcard Access-Control-Allow-Origin. A request
+# without an Origin (curl, Postman, MCP clients) gets the method/header
+# advertisements but no ACAO; a browser origin is echoed back only when it is
+# allow-listed, otherwise the request is refused outright.
 CORS_HEADERS=$(curl -s -I -X OPTIONS "http://localhost:${HTTP_PORT}/mcp" 2>/dev/null)
-assert_contains "CORS: Access-Control-Allow-Origin present" "$CORS_HEADERS" "Access-Control-Allow-Origin"
+assert_not_contains "CORS: no wildcard Access-Control-Allow-Origin" "$CORS_HEADERS" "Access-Control-Allow-Origin: *"
 assert_contains "CORS: Allows POST method" "$CORS_HEADERS" "POST"
 assert_contains "CORS: Exposes MCP-Session-Id" "$CORS_HEADERS" "MCP-Session-Id"
+
+CORS_EVIL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS -H "Origin: https://evil.example" "http://localhost:${HTTP_PORT}/mcp" 2>/dev/null)
+assert "CORS: unlisted browser origin refused with 403" "[ '$CORS_EVIL_CODE' = '403' ]"
+
+MCP_DELETE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://localhost:${HTTP_PORT}/mcp" 2>/dev/null)
+assert "Stateless /mcp rejects DELETE with 405 (cannot be shut down by a client)" "[ '$MCP_DELETE_CODE' = '405' ]"
+
+MCP_STILL_UP=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${HTTP_PORT}/health" 2>/dev/null)
+assert "Server still healthy after DELETE attempt" "[ '$MCP_STILL_UP' = '200' ]"
 
 # --------------------------------------------------------------------------
 # 3d. MCP Protocol: tools/list
@@ -307,16 +366,16 @@ for TOOL_NAME in browse_subreddit search_reddit get_post_details user_analysis r
   assert_contains "tools/list contains $TOOL_NAME" "$TOOLS_LIST" "$TOOL_NAME"
 done
 
-# Check readOnlyHint is set (NEW in v1.1.12)
+# readOnlyHint must sit under annotations - clients ignore it at the top level
 READONLY_COUNT=$(echo "$TOOLS_LIST" | node -e "
   let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{
     const r=JSON.parse(d);
     const tools=r.result?.tools||[];
-    const count=tools.filter(t=>t.readOnlyHint===true).length;
+    const count=tools.filter(t=>t.annotations && t.annotations.readOnlyHint===true).length;
     console.log(count);
   });
 " 2>/dev/null)
-assert "All 5 tools have readOnlyHint=true (NEW)" "[ '$READONLY_COUNT' = '5' ]"
+assert "All 5 tools have annotations.readOnlyHint=true" "[ '$READONLY_COUNT' = '5' ]"
 
 # Check schemas have proper structure (NEW zodSchemaToMCPInputSchema)
 SCHEMA_CHECK=$(echo "$TOOLS_LIST" | node -e "
@@ -362,23 +421,23 @@ log_subsection "4a. browse_subreddit"
 # Test 1: Default hot sort
 rate_limit_guard
 BROWSE_HOT=$(call_tool "browse_subreddit" '{"subreddit":"technology","limit":3}')
-assert_contains "browse_subreddit: returns posts array" "$BROWSE_HOT" '"posts"'
-assert_contains "browse_subreddit: posts have id field" "$BROWSE_HOT" '"id"'
-assert_contains "browse_subreddit: posts have title field" "$BROWSE_HOT" '"title"'
-assert_contains "browse_subreddit: posts have score field" "$BROWSE_HOT" '"score"'
-assert_contains "browse_subreddit: posts have permalink field" "$BROWSE_HOT" '"permalink"'
-assert_contains "browse_subreddit: posts have subreddit field" "$BROWSE_HOT" '"subreddit"'
-assert_contains "browse_subreddit: total_posts field present" "$BROWSE_HOT" '"total_posts"'
+assert_contains_live "browse_subreddit: returns posts array" "$BROWSE_HOT" '"posts"'
+assert_contains_live "browse_subreddit: posts have id field" "$BROWSE_HOT" '"id"'
+assert_contains_live "browse_subreddit: posts have title field" "$BROWSE_HOT" '"title"'
+assert_contains_live "browse_subreddit: posts have score field" "$BROWSE_HOT" '"score"'
+assert_contains_live "browse_subreddit: posts have permalink field" "$BROWSE_HOT" '"permalink"'
+assert_contains_live "browse_subreddit: posts have subreddit field" "$BROWSE_HOT" '"subreddit"'
+assert_contains_live "browse_subreddit: total_posts field present" "$BROWSE_HOT" '"total_posts"'
 
 # Test 2: Top with time range
 rate_limit_guard
 BROWSE_TOP=$(call_tool "browse_subreddit" '{"subreddit":"science","sort":"top","time":"month","limit":2}')
-assert_contains "browse_subreddit top/month: returns posts" "$BROWSE_TOP" '"posts"'
+assert_contains_live "browse_subreddit top/month: returns posts" "$BROWSE_TOP" '"posts"'
 
 # Test 3: Special subreddit "all" with rising
 rate_limit_guard
 BROWSE_ALL=$(call_tool "browse_subreddit" '{"subreddit":"all","sort":"rising","limit":2}')
-assert_contains "browse_subreddit r/all rising: works" "$BROWSE_ALL" '"posts"'
+assert_contains_live "browse_subreddit r/all rising: works" "$BROWSE_ALL" '"posts"'
 
 # Test 4: NSFW filtering (default=false)
 assert_not_contains "browse_subreddit: NSFW filtered out by default" "$BROWSE_HOT" '"nsfw":true'
@@ -386,28 +445,28 @@ assert_not_contains "browse_subreddit: NSFW filtered out by default" "$BROWSE_HO
 # Test 5: Include subreddit info
 rate_limit_guard_double  # subreddit_info makes 2 internal API calls
 BROWSE_INFO=$(call_tool "browse_subreddit" '{"subreddit":"programming","limit":1,"include_subreddit_info":true}')
-assert_contains "browse_subreddit: subreddit_info present" "$BROWSE_INFO" '"subreddit_info"'
-assert_contains "browse_subreddit: subreddit_info has subscribers" "$BROWSE_INFO" '"subscribers"'
+assert_contains_authed "browse_subreddit: subreddit_info present" "$BROWSE_INFO" '"subreddit_info"'
+assert_contains_authed "browse_subreddit: subreddit_info has subscribers" "$BROWSE_INFO" '"subscribers"'
 
 # Test 6: r/ prefix stripping
 rate_limit_guard
 BROWSE_PREFIX=$(call_tool "browse_subreddit" '{"subreddit":"r/AskReddit","limit":1}')
-assert_contains "browse_subreddit: r/ prefix stripped correctly" "$BROWSE_PREFIX" '"posts"'
+assert_contains_live "browse_subreddit: r/ prefix stripped correctly" "$BROWSE_PREFIX" '"posts"'
 
 # Test 7: controversial sort
 rate_limit_guard
 BROWSE_CONTROVERSIAL=$(call_tool "browse_subreddit" '{"subreddit":"AskReddit","sort":"controversial","time":"week","limit":2}')
-assert_contains "browse_subreddit controversial sort: returns posts" "$BROWSE_CONTROVERSIAL" '"posts"'
+assert_contains_live "browse_subreddit controversial sort: returns posts" "$BROWSE_CONTROVERSIAL" '"posts"'
 
 # Test 8: new sort
 rate_limit_guard
 BROWSE_NEW=$(call_tool "browse_subreddit" '{"subreddit":"technology","sort":"new","limit":2}')
-assert_contains "browse_subreddit new sort: returns posts" "$BROWSE_NEW" '"posts"'
+assert_contains_live "browse_subreddit new sort: returns posts" "$BROWSE_NEW" '"posts"'
 
 # Test 9: special subreddit "popular"
 rate_limit_guard
 BROWSE_POPULAR=$(call_tool "browse_subreddit" '{"subreddit":"popular","limit":2}')
-assert_contains "browse_subreddit r/popular: works" "$BROWSE_POPULAR" '"posts"'
+assert_contains_live "browse_subreddit r/popular: works" "$BROWSE_POPULAR" '"posts"'
 
 # --------------------------------------------------------------------------
 # 4b. search_reddit
@@ -416,33 +475,33 @@ log_subsection "4b. search_reddit"
 
 rate_limit_guard
 SEARCH_GLOBAL=$(call_tool "search_reddit" '{"query":"artificial intelligence","sort":"top","time":"week","limit":3}')
-assert_contains "search_reddit global: returns results" "$SEARCH_GLOBAL" '"results"'
-assert_contains "search_reddit global: has total_results" "$SEARCH_GLOBAL" '"total_results"'
+assert_contains_authed "search_reddit global: returns results" "$SEARCH_GLOBAL" '"results"'
+assert_contains_authed "search_reddit global: has total_results" "$SEARCH_GLOBAL" '"total_results"'
 
 # Multi-subreddit search with Promise.allSettled (NEW)
 rate_limit_guard_double  # 2 parallel subreddit searches
 SEARCH_MULTI=$(call_tool "search_reddit" '{"query":"python","subreddits":["programming","learnprogramming"],"limit":4}')
-assert_contains "search_reddit multi-subreddit (NEW allSettled): returns results" "$SEARCH_MULTI" '"results"'
+assert_contains_authed "search_reddit multi-subreddit (NEW allSettled): returns results" "$SEARCH_MULTI" '"results"'
 
 # Multi-subreddit with one invalid subreddit (NEW - failure tolerance)
 rate_limit_guard_double  # 2 parallel subreddit searches (one will 404)
-SEARCH_PARTIAL=$(call_tool "search_reddit" '{"query":"test","subreddits":["programming","thisdoesnotexist99999xyz"],"limit":4}')
-assert_contains "search_reddit partial failure (NEW): still returns results" "$SEARCH_PARTIAL" '"results"'
+SEARCH_PARTIAL=$(call_tool "search_reddit" '{"query":"test","subreddits":["programming","thisdoesnotexist9999"],"limit":4}')
+assert_contains_authed "search_reddit partial failure (NEW): still returns results" "$SEARCH_PARTIAL" '"results"'
 
 # Single subreddit search
 rate_limit_guard
 SEARCH_SINGLE=$(call_tool "search_reddit" '{"query":"python tutorial","subreddits":["learnprogramming"],"sort":"new","limit":3}')
-assert_contains "search_reddit single subreddit: returns results" "$SEARCH_SINGLE" '"results"'
+assert_contains_authed "search_reddit single subreddit: returns results" "$SEARCH_SINGLE" '"results"'
 
 # Sort by comments
 rate_limit_guard
 SEARCH_COMMENTS=$(call_tool "search_reddit" '{"query":"best programming language","sort":"comments","time":"month","limit":3}')
-assert_contains "search_reddit sort=comments: returns results" "$SEARCH_COMMENTS" '"results"'
+assert_contains_authed "search_reddit sort=comments: returns results" "$SEARCH_COMMENTS" '"results"'
 
 # Author filter (test with a known prolific user)
 rate_limit_guard
 SEARCH_AUTHOR=$(call_tool "search_reddit" '{"query":"reddit","author":"spez","sort":"new","limit":5}')
-assert_contains "search_reddit author filter: returns results" "$SEARCH_AUTHOR" '"results"'
+assert_contains_authed "search_reddit author filter: returns results" "$SEARCH_AUTHOR" '"results"'
 # Verify all returned results are by that author (if any results)
 AUTHOR_CHECK=$(echo "$SEARCH_AUTHOR" | node -e "
   let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{
@@ -452,12 +511,12 @@ AUTHOR_CHECK=$(echo "$SEARCH_AUTHOR" | node -e "
     console.log(allMatch ? 'pass' : 'fail');
   });
 " 2>/dev/null)
-assert "search_reddit author filter: all results match author" "[ '$AUTHOR_CHECK' = 'pass' ]"
+assert_authed "search_reddit author filter: all results match author" "[ '$AUTHOR_CHECK' = 'pass' ]"
 
 # Flair filter (search in a subreddit known to use flairs)
 rate_limit_guard
 SEARCH_FLAIR=$(call_tool "search_reddit" '{"query":"help","subreddits":["technology"],"flair":"Privacy","sort":"top","time":"year","limit":5}')
-assert_contains "search_reddit flair filter: returns results" "$SEARCH_FLAIR" '"results"'
+assert_contains_authed "search_reddit flair filter: returns results" "$SEARCH_FLAIR" '"results"'
 # Verify flair filtering worked (all results should have matching flair or be empty)
 FLAIR_CHECK=$(echo "$SEARCH_FLAIR" | node -e "
   let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{
@@ -467,7 +526,7 @@ FLAIR_CHECK=$(echo "$SEARCH_FLAIR" | node -e "
     console.log(allMatch ? 'pass' : 'fail');
   });
 " 2>/dev/null)
-assert "search_reddit flair filter: results match flair" "[ '$FLAIR_CHECK' = 'pass' ]"
+assert_authed "search_reddit flair filter: results match flair" "[ '$FLAIR_CHECK' = 'pass' ]"
 
 # --------------------------------------------------------------------------
 # 4c. get_post_details
@@ -492,9 +551,9 @@ if [ -n "$POST_ID" ] && [ -n "$POST_SUB" ]; then
   # Test with post_id + subreddit (efficient, 1 API call)
   rate_limit_guard
   POST_DETAILS=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"comment_limit\":3,\"max_top_comments\":2}")
-  assert_contains "get_post_details by ID+sub: has post field" "$POST_DETAILS" '"post"'
-  assert_contains "get_post_details by ID+sub: has top_comments" "$POST_DETAILS" '"top_comments"'
-  assert_contains "get_post_details by ID+sub: has total_comments" "$POST_DETAILS" '"total_comments"'
+  assert_contains_authed "get_post_details by ID+sub: has post field" "$POST_DETAILS" '"post"'
+  assert_contains_authed "get_post_details by ID+sub: has top_comments" "$POST_DETAILS" '"top_comments"'
+  assert_contains_authed "get_post_details by ID+sub: has total_comments" "$POST_DETAILS" '"total_comments"'
 
   # Test with URL format (NEW enhanced parser)
   POST_PERMALINK=$(echo "$BROWSE_HOT" | node -e "
@@ -507,49 +566,49 @@ if [ -n "$POST_ID" ] && [ -n "$POST_SUB" ]; then
   if [ -n "$POST_PERMALINK" ]; then
     rate_limit_guard
     POST_BY_URL=$(call_tool "get_post_details" "{\"url\":\"${POST_PERMALINK}\",\"comment_limit\":2,\"max_top_comments\":1}")
-    assert_contains "get_post_details by URL: has post field" "$POST_BY_URL" '"post"'
+    assert_contains_authed "get_post_details by URL: has post field" "$POST_BY_URL" '"post"'
   fi
 
   # Test comment sorting
   rate_limit_guard
   POST_TOP_SORT=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"comment_sort\":\"top\",\"comment_limit\":3,\"max_top_comments\":2}")
-  assert_contains "get_post_details comment_sort=top: works" "$POST_TOP_SORT" '"top_comments"'
+  assert_contains_authed "get_post_details comment_sort=top: works" "$POST_TOP_SORT" '"top_comments"'
 
   # Test link extraction (EXISTING)
   rate_limit_guard
   POST_LINKS=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"extract_links\":true,\"comment_limit\":5,\"max_top_comments\":2}")
-  assert_contains "get_post_details extract_links: has field" "$POST_LINKS" '"extracted_links"'
+  assert_contains_authed "get_post_details extract_links: has field" "$POST_LINKS" '"extracted_links"'
 
   # Test comment_depth parameter
   rate_limit_guard
   POST_DEPTH=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"comment_depth\":1,\"comment_limit\":5,\"max_top_comments\":3}")
-  assert_contains "get_post_details comment_depth=1: works" "$POST_DEPTH" '"top_comments"'
+  assert_contains_authed "get_post_details comment_depth=1: works" "$POST_DEPTH" '"top_comments"'
 
   # Test comment_sort=new
   rate_limit_guard
   POST_NEW_SORT=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"comment_sort\":\"new\",\"comment_limit\":3,\"max_top_comments\":2}")
-  assert_contains "get_post_details comment_sort=new: works" "$POST_NEW_SORT" '"top_comments"'
+  assert_contains_authed "get_post_details comment_sort=new: works" "$POST_NEW_SORT" '"top_comments"'
 
   # Test comment_sort=controversial
   rate_limit_guard
   POST_CONTR_SORT=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"comment_sort\":\"controversial\",\"comment_limit\":3,\"max_top_comments\":2}")
-  assert_contains "get_post_details comment_sort=controversial: works" "$POST_CONTR_SORT" '"top_comments"'
+  assert_contains_authed "get_post_details comment_sort=controversial: works" "$POST_CONTR_SORT" '"top_comments"'
 
   # Test comment_sort=qa
   rate_limit_guard
   POST_QA_SORT=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"subreddit\":\"${POST_SUB}\",\"comment_sort\":\"qa\",\"comment_limit\":3,\"max_top_comments\":2}")
-  assert_contains "get_post_details comment_sort=qa: works" "$POST_QA_SORT" '"top_comments"'
+  assert_contains_authed "get_post_details comment_sort=qa: works" "$POST_QA_SORT" '"top_comments"'
 
   # Test post_id only (no subreddit — triggers /api/info lookup for subreddit discovery)
   rate_limit_guard_double  # 2 API calls: /api/info + /comments
   POST_ID_ONLY=$(call_tool "get_post_details" "{\"post_id\":\"${POST_ID}\",\"comment_limit\":2,\"max_top_comments\":1}")
-  assert_contains "get_post_details post_id only (no subreddit): works" "$POST_ID_ONLY" '"post"'
+  assert_contains_authed "get_post_details post_id only (no subreddit): works" "$POST_ID_ONLY" '"post"'
 
   # Test _postid format (redd.it short URL output) — NEW: empty subreddit prefix
   rate_limit_guard_double  # /api/info + /comments
   POST_SHORT_ID="_${POST_ID}"
   POST_SHORT=$(call_tool "get_post_details" "{\"post_id\":\"${POST_SHORT_ID}\",\"comment_limit\":1,\"max_top_comments\":1}")
-  assert_contains "get_post_details _postid format (redd.it path): works" "$POST_SHORT" '"post"'
+  assert_contains_authed "get_post_details _postid format (redd.it path): works" "$POST_SHORT" '"post"'
 else
   skip_test "get_post_details tests" "Could not extract post ID from browse results"
 fi
@@ -561,28 +620,28 @@ log_subsection "4d. user_analysis"
 
 rate_limit_guard
 USER_ANALYSIS=$(call_tool "user_analysis" '{"username":"spez","posts_limit":3,"comments_limit":3,"time_range":"year","top_subreddits_limit":5}')
-assert_contains "user_analysis: has username" "$USER_ANALYSIS" '"username"'
-assert_contains "user_analysis: has karma object" "$USER_ANALYSIS" '"karma"'
-assert_contains "user_analysis: has accountAge" "$USER_ANALYSIS" '"accountAge"'
-assert_contains "user_analysis: has recentPosts" "$USER_ANALYSIS" '"recentPosts"'
-assert_contains "user_analysis: has recentComments" "$USER_ANALYSIS" '"recentComments"'
-assert_contains "user_analysis: has topSubreddits" "$USER_ANALYSIS" '"topSubreddits"'
+assert_contains_authed "user_analysis: has username" "$USER_ANALYSIS" '"username"'
+assert_contains_authed "user_analysis: has karma object" "$USER_ANALYSIS" '"karma"'
+assert_contains_authed "user_analysis: has accountAge" "$USER_ANALYSIS" '"accountAge"'
+assert_contains_authed "user_analysis: has recentPosts" "$USER_ANALYSIS" '"recentPosts"'
+assert_contains_authed "user_analysis: has recentComments" "$USER_ANALYSIS" '"recentComments"'
+assert_contains_authed "user_analysis: has topSubreddits" "$USER_ANALYSIS" '"topSubreddits"'
 
 # Test with posts_limit=0 (only comments — verifies comments-only path)
 rate_limit_guard
 USER_COMMENTS_ONLY=$(call_tool "user_analysis" '{"username":"spez","posts_limit":0,"comments_limit":3,"time_range":"all"}')
-assert_contains "user_analysis posts_limit=0: still returns data" "$USER_COMMENTS_ONLY" '"username"'
-assert_contains "user_analysis posts_limit=0: has karma" "$USER_COMMENTS_ONLY" '"karma"'
+assert_contains_authed "user_analysis posts_limit=0: still returns data" "$USER_COMMENTS_ONLY" '"username"'
+assert_contains_authed "user_analysis posts_limit=0: has karma" "$USER_COMMENTS_ONLY" '"karma"'
 
 # Test with comments_limit=0 (only posts)
 rate_limit_guard
 USER_POSTS_ONLY=$(call_tool "user_analysis" '{"username":"spez","posts_limit":5,"comments_limit":0,"time_range":"all"}')
-assert_contains "user_analysis comments_limit=0: has recentPosts" "$USER_POSTS_ONLY" '"recentPosts"'
+assert_contains_authed "user_analysis comments_limit=0: has recentPosts" "$USER_POSTS_ONLY" '"recentPosts"'
 
 # Test time_range=day (likely triggers fallback to 'all' since spez may not post daily)
 rate_limit_guard
 USER_DAY=$(call_tool "user_analysis" '{"username":"spez","posts_limit":3,"comments_limit":0,"time_range":"day"}')
-assert_contains "user_analysis time_range=day: returns data" "$USER_DAY" '"username"'
+assert_contains_authed "user_analysis time_range=day: returns data" "$USER_DAY" '"username"'
 # Check if timeRangeNote appears (fallback behavior NEW in v1.1.12)
 USER_DAY_HAS_NOTE=$(echo "$USER_DAY" | node -e "
   let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{
@@ -593,12 +652,12 @@ USER_DAY_HAS_NOTE=$(echo "$USER_DAY" | node -e "
     console.log((hasPosts || hasNote) ? 'pass' : 'fail');
   });
 " 2>/dev/null)
-assert "user_analysis time_range=day: either has posts or fallback note" "[ '$USER_DAY_HAS_NOTE' = 'pass' ]"
+assert_authed "user_analysis time_range=day: either has posts or fallback note" "[ '$USER_DAY_HAS_NOTE' = 'pass' ]"
 
 # Test time_range=week
 rate_limit_guard
 USER_WEEK=$(call_tool "user_analysis" '{"username":"spez","posts_limit":3,"comments_limit":0,"time_range":"week"}')
-assert_contains "user_analysis time_range=week: returns data" "$USER_WEEK" '"username"'
+assert_contains_authed "user_analysis time_range=week: returns data" "$USER_WEEK" '"username"'
 
 # --------------------------------------------------------------------------
 # 4e. reddit_explain
@@ -690,14 +749,14 @@ assert_contains "user_analysis nonexistent user: returns error" "$ERR_BAD_USER" 
 # Multi-subreddit search with nonexistent subreddits (Reddit search API returns empty, not 404)
 rate_limit_guard_double  # 2 parallel searches
 ERR_ALL_EMPTY=$(call_tool "search_reddit" '{"query":"test","subreddits":["nonexistent999aaa","nonexistent999bbb"],"limit":2}')
-assert_contains "search_reddit nonexistent subs: returns empty results gracefully" "$ERR_ALL_EMPTY" '"results"'
+assert_contains_authed "search_reddit nonexistent subs: returns empty results gracefully" "$ERR_ALL_EMPTY" '"results"'
 EMPTY_COUNT=$(echo "$ERR_ALL_EMPTY" | node -e "
   let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{
     const o=JSON.parse(d);
     console.log(o.total_results === 0 ? 'pass' : 'fail');
   });
 " 2>/dev/null)
-assert "search_reddit nonexistent subs: total_results is 0" "[ '$EMPTY_COUNT' = 'pass' ]"
+assert_authed "search_reddit nonexistent subs: total_results is 0" "[ '$EMPTY_COUNT' = 'pass' ]"
 
 # --------------------------------------------------------------------------
 # 5c. Invalid URL Formats

--- a/tests/test-unit.sh
+++ b/tests/test-unit.sh
@@ -1208,6 +1208,139 @@ AUTH_PRIVACY_RESULT=$(HOME="$(mktemp -d)" REDDIT_CLIENT_ID="testid" REDDIT_CLIEN
 ' 2>/dev/null)
 assert "Auth privacy: env creds never hit disk, --auth persists sans password, custom UA honored" "echo \"\$AUTH_PRIVACY_RESULT\" | grep -q '^pass$'"
 
+# --------------------------------------------------------------------------
+# 2v. Identifier Validation: no path traversal into Reddit endpoints — NEW
+# --------------------------------------------------------------------------
+log_subsection "2v. Identifier Validation — NEW"
+
+IDENT_RESULT=$(node --input-type=module -e '
+  import { browseSubredditSchema, searchRedditSchema, getPostDetailsSchema, userAnalysisSchema } from "./dist/tools/index.js";
+
+  // Every identifier is interpolated into a Reddit API path, and authenticated
+  // requests carry the users OAuth bearer token — these must never accept a
+  // value that can escape /r/ or inject a query string.
+  const badSubs = ["../../api/v1/me", "programming/../../user/spez/about.json", "x?limit=1",
+                   "prog/hot.json?x=", "a".repeat(50), "../../../", "sub reddit", "", "a/b",
+                   "a".repeat(22), "+tech", "tech+", "u_bad-name/../x"];
+  const t1 = badSubs.every(s => !browseSubredditSchema.safeParse({ subreddit: s }).success);
+  const t2 = !userAnalysisSchema.safeParse({ username: "../../api/v1/me" }).success
+    && ["spez", "Adjective-Noun-1234", "a_b-c"].every(u => userAnalysisSchema.safeParse({ username: u }).success);
+  const t3 = !getPostDetailsSchema.safeParse({ post_id: "../../x" }).success;
+  const t4 = !searchRedditSchema.safeParse({ query: "x", subreddits: ["ok", "../../api/v1/me"] }).success;
+
+  // Legitimate values keep working, including the special listings and
+  // user-profile subreddits
+  // Profile subreddits carry the username verbatim, and modern Reddit
+  // usernames are Adjective-Noun-#### (hyphens, up to 20 chars). Multireddit
+  // paths (a+b) are served under /r/ too.
+  const t5 = ["all", "popular", "technology", "u_someone", "u_Adjective-Noun-1234",
+              "u_twenty_char_usernam", "technology+science", "AskReddit", "ab"]
+    .every(s => browseSubredditSchema.safeParse({ subreddit: s }).success);
+
+  // Prefixes are normalized rather than rejected
+  const t6 = browseSubredditSchema.parse({ subreddit: "r/technology" }).subreddit === "technology";
+  const t7 = userAnalysisSchema.parse({ username: "u/spez" }).username === "spez";
+  const t8 = getPostDetailsSchema.parse({ post_id: "t3_1abc2d3" }).post_id === "1abc2d3";
+
+  const all = t1 && t2 && t3 && t4 && t5 && t6 && t7 && t8;
+  console.log(all ? "pass" : "fail:" + JSON.stringify({t1,t2,t3,t4,t5,t6,t7,t8}));
+' 2>/dev/null)
+assert "Identifier validation: traversal/query-injection rejected, prefixes normalized" "echo \"\$IDENT_RESULT\" | grep -q '^pass$'"
+
+# --------------------------------------------------------------------------
+# 2w. Cache Integrity: client-side filters must not mutate cached data — NEW
+# --------------------------------------------------------------------------
+log_subsection "2w. Cache Integrity — NEW"
+
+CACHE_INTEGRITY_RESULT=$(node --input-type=module -e '
+  import { AuthManager } from "./dist/core/auth.js";
+  import { RateLimiter } from "./dist/core/rate-limiter.js";
+  import { CacheManager } from "./dist/core/cache.js";
+  import { RedditAPI } from "./dist/services/reddit-api.js";
+  import { RedditTools } from "./dist/tools/index.js";
+
+  const mk = () => {
+    const api = new RedditAPI({
+      authManager: new AuthManager(),
+      rateLimiter: new RateLimiter({ limit: 100, window: 60000, name: "test" }),
+      cacheManager: new CacheManager({ defaultTTL: 60000, maxSize: 5000000 }),
+    });
+    return new RedditTools(api);
+  };
+  const listing = (n) => ({ kind: "Listing", data: { after: null, before: null, children:
+    Array.from({ length: n }, (_, i) => ({ kind: "t3", data: {
+      id: "p" + i, title: "t" + i, author: i === 0 ? "alice" : "bob", score: 1, num_comments: 0,
+      created_utc: 1, url: "u", permalink: "/p", subreddit: "test", is_self: false,
+      over_18: i === 1, link_flair_text: i === 0 ? "News" : "Other" } })) } });
+
+  globalThis.fetch = async () => new Response(JSON.stringify(listing(5)), { status: 200, headers: { "content-type": "application/json" } });
+
+  // search: the cache key excludes author/flair, so filtering must not shrink
+  // the cached listing for later unfiltered callers
+  const t = mk();
+  const filtered = await t.searchReddit({ query: "q", sort: "relevance", time: "all", limit: 25, author: "alice" });
+  const unfiltered = await t.searchReddit({ query: "q", sort: "relevance", time: "all", limit: 25 });
+  const t1 = filtered.total_results === 1;
+  const t2 = unfiltered.total_results === 5;
+  // filter-after-limit shrinkage is disclosed rather than silent
+  const t3 = typeof filtered.filter_note === "string" && /limit/.test(filtered.filter_note);
+
+  // browse: same contract for the NSFW filter (key excludes include_nsfw)
+  const t4tools = mk();
+  const safe = await t4tools.browseSubreddit({ subreddit: "test", sort: "hot", limit: 25, include_nsfw: false });
+  const withNsfw = await t4tools.browseSubreddit({ subreddit: "test", sort: "hot", limit: 25, include_nsfw: true });
+  const t4 = safe.total_posts === 4 && withNsfw.total_posts === 5;
+
+  // null-shaped children must not crash the comment tree
+  const postL = { kind: "Listing", data: { children: [{ kind: "t3", data: { id: "a1", title: "T", author: "x", score: 1, num_comments: 1, created_utc: 1, url: "u", permalink: "/p", subreddit: "test", selftext: "", is_self: true } }] } };
+  const cmtL = { kind: "Listing", data: { children: [
+    { kind: "t1", data: { id: "c1", author: "a", body: "hi", score: 1, created_utc: 1, permalink: "/c" } },
+    { kind: "t1", data: null }, { kind: "more", data: { count: 5 } }] } };
+  globalThis.fetch = async () => new Response(JSON.stringify([postL, cmtL]), { status: 200, headers: { "content-type": "application/json" } });
+  let t5 = false;
+  try {
+    const r = await mk().getPostDetails({ post_id: "a1", subreddit: "test", comment_limit: 20, comment_sort: "best", comment_depth: 3, extract_links: false, max_top_comments: 5 });
+    t5 = r.total_comments === 1;
+  } catch { t5 = false; }
+
+  // an empty post listing yields a clear message, not a TypeError
+  globalThis.fetch = async () => new Response(JSON.stringify([{ kind: "Listing", data: { children: [] } }, { kind: "Listing", data: { children: [] } }]), { status: 200, headers: { "content-type": "application/json" } });
+  let t6 = false;
+  try {
+    await mk().getPostDetails({ post_id: "zz9", subreddit: "test", comment_limit: 20, comment_sort: "best", comment_depth: 3, extract_links: false, max_top_comments: 5 });
+  } catch (e) { t6 = !/Cannot read/.test(e.message) && /no post/i.test(e.message); }
+
+  const all = t1 && t2 && t3 && t4 && t5 && t6;
+  console.log(all ? "pass" : "fail:" + JSON.stringify({t1,t2,t3,t4,t5,t6}));
+' 2>/dev/null)
+assert "Cache integrity: filters do not mutate cached listings; null-shaped children survive" "echo \"\$CACHE_INTEGRITY_RESULT\" | grep -q '^pass$'"
+
+# --------------------------------------------------------------------------
+# 2x. Tool Definition Shape: annotations + schema fidelity — NEW
+# --------------------------------------------------------------------------
+log_subsection "2x. Tool Definition Shape — NEW"
+
+TOOLDEF_RESULT=$(HOME="$(mktemp -d)" node --input-type=module -e '
+  import { createMCPServer } from "./dist/mcp-server.js";
+  const { handlers } = await createMCPServer();
+  const { tools } = await handlers["tools/list"]();
+
+  const t1 = tools.length === 5;
+  // readOnlyHint belongs under annotations; at the top level clients drop it
+  const t2 = tools.every(t => t.annotations && t.annotations.readOnlyHint === true);
+  const t3 = tools.every(t => t.readOnlyHint === undefined);
+  // input schemas must survive zod->JSON Schema conversion with real properties
+  const t4 = tools.every(t => t.inputSchema && t.inputSchema.type === "object" && Object.keys(t.inputSchema.properties || {}).length > 0);
+  const browse = tools.find(t => t.name === "browse_subreddit");
+  const t5 = browse.inputSchema.properties.subreddit.type === "string"
+    && typeof browse.inputSchema.properties.subreddit.description === "string"
+    && (browse.inputSchema.required || []).includes("subreddit");
+
+  const all = t1 && t2 && t3 && t4 && t5;
+  console.log(all ? "pass" : "fail:" + JSON.stringify({t1,t2,t3,t4,t5}));
+' 2>/dev/null)
+assert "Tool definitions: 5 tools, readOnlyHint under annotations, schemas intact" "echo \"\$TOOLDEF_RESULT\" | grep -q '^pass$'"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # RESULTS


### PR DESCRIPTION
## Summary

Security and correctness fixes from a full-repo audit, plus the version bump to **1.1.14** that finally ships the RSS fallback (#62) to users — npm, the `.mcpb` bundle and the MCP registry all still serve pre-RSS code today.

Three areas: HTTP mode hardening, tool-input validation, and cache/CI correctness.

## HTTP mode

HTTP mode is the only remotely reachable surface, and it had no authentication by design. It now behaves accordingly:

- **Per-request Server + transport.** One shared stateless transport was reused for the process lifetime, which leaks responses across clients ([GHSA-345p-7cg4-v4c7](https://github.com/advisories/GHSA-345p-7cg4-v4c7)) and let a single unauthenticated `DELETE /mcp` permanently brick the endpoint while `/health` kept reporting `ok`. SDK 1.29 rejects the old shape outright (`Stateless transport cannot be reused across requests`), so the bump required this. Cache, rate limiter and Reddit client stay process-wide via a new `createSharedServices()`.
- **Binds `127.0.0.1`** by default (`REDDIT_BUDDY_HOST` overrides). It previously bound every interface while printing `localhost`, so any host on the LAN could drive it.
- **No wildcard CORS.** Browser origins must appear in `REDDIT_BUDDY_ALLOWED_ORIGINS` or the request is refused; non-browser clients (Postman, curl, MCP clients) send no `Origin` and are unaffected. The preflight now allows `MCP-Protocol-Version`, which the SDK client sends on every request after `initialize`.
- **`GET`/`DELETE` on `/mcp` return 405** — stateless mode has no session to stream or terminate, and the official client treats 405 as expected.
- **DNS-rebinding protection** with a loopback allowlist. On a deliberately non-loopback bind the Host check is off unless `REDDIT_BUDDY_ALLOWED_HOSTS` is set, because containers legitimately arrive with the published port, container IP or compose service name in `Host`.
- `@modelcontextprotocol/sdk` `^1.17.5` → `^1.29.0` (CVE-2026-25536).

## Tool input validation

`subreddit`, `username` and `post_id` were bare `z.string()` interpolated straight into Reddit API paths — and an authenticated request carries the user's OAuth bearer token, so a model-supplied `../../api/v1/me` could steer that token to an arbitrary endpoint. They are now format-validated at the schema boundary, with `encodeURIComponent` at every interpolation site so direct library use is covered too.

Prefixes (`r/`, `u/`, `t3_`) are normalized rather than rejected, and the accepted set still covers profile subreddits (`u_name`, including hyphenated and 20-char usernames) and multireddits (`a+b`).

## Correctness

- **Cache mutation.** The search author/flair filters and the browse NSFW filter built their result by reassigning `listing.data.children` on the object the cache returned *by reference*, and none of those params are in the cache key. One filtered search therefore shrank the shared cache entry for every later caller for the full TTL. They now build new arrays. `search_reddit` also discloses filter-after-limit shrinkage instead of silently returning fewer results.
- **Null-shape guards** for `{kind, data:null}` children and empty post listings; both surfaced raw `TypeError`s to the model.
- **`readOnlyHint` moved under `annotations`** (clients ignore it at the top level), and the ~1KB of tool-routing guidance moved to `instructions` — as a `serverInfo.description` field it was dropped by the protocol, so the model never saw it.

## CI and release

- **Version-parity job.** `package.json`, `server.json` (×2), `manifest.json`, `bundle.config.json` and `SERVER_VERSION` must agree. `manifest.json` had drifted to 1.1.12, so the released `.mcpb` misreported its own version inside Claude Desktop.
- **Integration job is no longer `continue-on-error`.** It was hiding **36 of 104 failing asserts** behind a green check. Checks that genuinely need credentials, and live browse checks that Reddit throttles (HTTP 429 on the logged-out RSS feed), now *skip* on that signal, so a red run means a real regression. Two asserts that passed vacuously on empty result sets are gated too.
- **Removed unused `vitest` devDependencies** — both npm CRITICAL advisories and 4 highs came from them, and no vitest test ever existed in this repo's history.

## Test plan

- [x] `npm run build` and `npm run typecheck` clean
- [x] Unit suite **45/45**, including new sections for identifier validation (traversal rejected, real Reddit shapes accepted), cache integrity (filters do not mutate cached listings; null children survive) and tool-definition shape
- [x] Integration suite anonymously: **69 passed / 0 failed / 38 skipped** (was 36 silent failures)
- [x] Docker image rebuilt and probed: reachable via published port, container IP and service name; loopback default still rejects a spoofed `Host` with 403
- [x] Live stdio MCP session: pure JSON-RPC on stdout, `instructions` reaches the client, 5 tools with `annotations.readOnlyHint`
- [x] Adversarial multi-agent review of this diff; every confirmed finding fixed, including a blocker where the DNS-rebinding allowlist made the Docker image return 403 on every network-reachable path

Generated with Claude Code
