### PR TITLE
ci: fix MCP registry publish (bad flag, stale publisher, changed asset path)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write  # Required to create GitHub Releases
 
     env:
-      MCP_PUBLISHER_VERSION: "1.2.0"
+      MCP_PUBLISHER_VERSION: "1.8.0"
 
     steps:
       - name: Checkout repository
@@ -78,7 +78,8 @@ jobs:
       - name: Install MCP Publisher
         run: |
           echo "📥 Downloading MCP Publisher v${{ env.MCP_PUBLISHER_VERSION }}..."
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v${{ env.MCP_PUBLISHER_VERSION }}/mcp-publisher_${{ env.MCP_PUBLISHER_VERSION }}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" -o mcp-publisher.tar.gz
+          # Release assets dropped the version from their filename after 1.2.0
+          curl -fL "https://github.com/modelcontextprotocol/registry/releases/download/v${{ env.MCP_PUBLISHER_VERSION }}/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" -o mcp-publisher.tar.gz
 
           echo "📦 Extracting..."
           tar xzf mcp-publisher.tar.gz
@@ -91,8 +92,12 @@ jobs:
           chmod +x ./mcp-publisher
           ./mcp-publisher --version || echo "Version check failed, continuing..."
 
+      # `login github-oidc` only accepts -registry; the --audience flag added in
+      # #54 does not exist in any published mcp-publisher, which is why every
+      # release since v1.1.13 failed here. The wrong-audience error that #54
+      # was chasing came from publisher 1.2.0 itself and is fixed upstream.
       - name: Login to MCP Registry
-        run: ./mcp-publisher login github-oidc --audience https://registry.modelcontextprotocol.io
+        run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
         run: |


### PR DESCRIPTION
## Summary

Every release since v1.1.13 has failed at **Login to MCP Registry**, leaving the MCP registry stuck on **1.1.12** while npm advanced to 1.1.14. Today's `v1.1.14` run failed there too — npm publish and the GitHub release both succeeded, only the registry step did not.

Three separate problems, all in that one step:

- **`--audience` is not a real flag.** `mcp-publisher login github-oidc` exposes only `-registry`. I downloaded both 1.2.0 and 1.8.0 and read their actual usage output to confirm. The flag added in #54 makes the step exit 2 with `flag provided but not defined: -audience`.
- **The publisher pin was stale.** 1.2.0 was built 2025-09-30. The wrong-audience error #54 was chasing (`expected https://registry.modelcontextprotocol.io, got [mcp-registry]`) came from 1.2.0 requesting the OIDC token itself, and is fixed upstream. Bumped to **1.8.0**.
- **The download URL template 404s on anything newer.** Release assets dropped the version from their filename after 1.2.0 (`mcp-publisher_1.2.0_linux_amd64.tar.gz` → `mcp-publisher_linux_amd64.tar.gz`). Also added `curl -f`, so a bad URL fails the download step instead of silently saving an HTML error page and failing confusingly at `tar`.

## Test plan

- [x] Downloaded mcp-publisher 1.2.0 and 1.8.0 and confirmed `login github-oidc` accepts only `-registry` in both
- [x] Resolved the exact URL the runner will build for linux/amd64 → HTTP 200
- [x] Confirmed `publish` still takes `./server.json` with the repo's current schema
- [ ] Re-run the `v1.1.14` tag after merge; npm publish self-skips (already published) and the release action updates in place, so only the registry steps do new work

Generated with Claude Code