### PR TITLE
fix: bring server.json description under the MCP registry's 100-char limit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,19 @@ jobs:
           done
           [ "$FAILED" = "0" ] || exit 1
 
+      # The MCP registry rejects a description over 100 characters with a 422,
+      # and that step runs after npm publish and the GitHub release - so catch
+      # it here instead of half-way through a release.
+      - name: Check server.json description length
+        run: |
+          DESC=$(jq -r .description server.json)
+          LEN=${#DESC}
+          echo "server.json description: $LEN chars"
+          if [ "$LEN" -gt 100 ]; then
+            echo "::error::server.json description is $LEN chars; the MCP registry allows at most 100"
+            exit 1
+          fi
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.karanb192/reddit-mcp-buddy",
   "version": "1.1.14",
-  "description": "Reddit browser for AI assistants. Browse posts without API keys; add Reddit credentials to also search, read comments, and analyze users.",
+  "description": "Reddit browser for AI assistants. Browse without API keys; add credentials for search and analysis.",
   "author": {
     "name": "Karan Bansal",
     "email": "karanb192@gmail.com",


### PR DESCRIPTION
## Summary

The `v1.1.14` publish now gets past login (fixed in #67) and fails at the next step with:

```
server returned status 422: {"detail":"validation failed","errors":[
  {"message":"expected length <= 100","location":"body.description","value":"Reddit browser for AI assistants. Browse posts without API keys; add Reddit credentials to also search, read comments, and analyze users."}]}
```

#62 rewrote that field to **137 characters** to scope the "no API keys" claim to browsing only. The wording was right; the length was not. It went unnoticed because the registry publish step has not run successfully since v1.1.12, so nothing ever validated the field.

- Reworded to **99 characters**, keeping the scoping #62 was after: `Reddit browser for AI assistants. Browse without API keys; add credentials for search and analysis.`
- **CI guard:** the registry step runs *after* `npm publish` and the GitHub release, so a 422 there leaves a half-published release. The Version Parity job now fails the build when the description exceeds 100 characters.

## Test plan

- [x] `jq -r .description server.json | wc -c` → 99 characters
- [x] New CI step passes on the current value and fails on an over-length one
- [ ] Re-run the `v1.1.14` tag after merge and confirm the registry reports 1.1.14 as `isLatest`

Generated with Claude Code