### PR TITLE
chore: ignore local .gstack/ debug captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ CLAUDE.md
 
 # Desktop extension bundles
 *.mcpb
+.gstack/


### PR DESCRIPTION
Adds `.gstack/` (local debug-capture logs) to .gitignore and fixes the missing trailing newline after `*.mcpb`. No code changes.